### PR TITLE
CJ2 Edits and Ref updates

### DIFF
--- a/draft-ietf-rtcweb-jsep-03.xml
+++ b/draft-ietf-rtcweb-jsep-03.xml
@@ -573,9 +573,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
       concepts.</t>
 
       <section title="SDP Requirements">
-        <t>Note: The text in this section may not represent working group
-        consensus and is put here so that the working group can discuss it and
-        find out how to change it such that it does have consensus.</t>
 
         <t>When generating SDP blobs, either for offers or answers, the
         generated SDP needs to conform to the following specifications.


### PR DESCRIPTION
 Mostly this is all just fixes for the references, reformatting to fit in 72 columns, but I did delete a word out of abstract and made a few real changes to the "SDP Requirements" section that show up in the diff file attached to this patch as changes around line 621 to 636. I suspect you will be fine with them but you need to review them. It was things like saying SDES was MUST NOT instead of MAY. 

In all the new stuff you wrote in createOffer etc, I did not change anything other than fixing references so no real changes there. 
