### PR TITLE
fixed references to drafts that have moved to RFC or WG

### DIFF
--- a/draft-ietf-rtcweb-jsep-06.xml
+++ b/draft-ietf-rtcweb-jsep-06.xml
@@ -1199,7 +1199,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               used for sending media, along with the mandatory "cname" source
               attribute, as specified in Section 6.1, indicating the CNAME for
               the source. The CNAME must be generated in accordance with 
-              draft-rescorla-random-cname-00. [OPEN ISSUE: How are CNAMEs
+              <xref target="RFC7022"></xref>. [OPEN ISSUE: How are CNAMEs
               specified for MSTs? Are they randomly generated for each
               MediaStream? If so, can two MediaStreams be synced?]</t>
 
@@ -1259,7 +1259,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
           <t>Note that when BUNDLE is used, any additional attributes that are
           added MUST follow the advice in <xref
-          target="I-D.nandakumar-mmusic-sdp-mux-attributes"></xref> on how
+          target="I-D.ietf-mmusic-sdp-mux-attributes"></xref> on how
           those attributes interact with BUNDLE.</t>
         </section>
 
@@ -2098,44 +2098,25 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
       <!-- NORM 6 -->
 
-      <reference anchor="I-D.nandakumar-mmusic-sdp-mux-attributes">
+      <!-- NORM 7 -->
+
+      <reference anchor='I-D.ietf-mmusic-sdp-mux-attributes'>
         <front>
           <title>A Framework for SDP Attributes when Multiplexing</title>
-
-          <author fullname="Suhas Nandakumar" initials="S"
-                  surname="Nandakumar">
-            <organization></organization>
+          
+          <author initials='S' surname='Nandakumar' fullname='Suhas Nandakumar'>
+            <organization />
           </author>
-
-          <date day="15" month="July" year="2013" />
-
-          <abstract>
-            <t>The Session Description Protocol (SDP) provides mechanisms to
-            describe attributes of multimedia sessions and of individual media
-            streams (e.g., Real-time Transport Protocol (RTP) sessions) within
-            a multimedia session. In the RTCWeb WG, there is a need to use a
-            single 5-tuple for sending and receiving media associated with
-            multiple media descriptions ("m=" lines). Such a requirement has
-            raised concerns over the semantic implications of the SDP
-            attributes associated with the RTP Sessions multiplexed over a
-            single transport layer flow. The scope of this specification is to
-            provide a framework for analyzing the multiplexing characteristics
-            of SDP attributes. The specification also categorizes existing
-            attributes based on the framework described herein.</t>
-          </abstract>
+          
+          <date month='February' day='14' year='2014' />
+          
         </front>
-
-        <seriesInfo name="Internet-Draft"
-                    value="draft-nandakumar-mmusic-sdp-mux-attributes-03" />
-
-        <format target="http://www.ietf.org/internet-drafts/draft-nandakumar-mmusic-sdp-mux-attributes-03.txt"
-                type="TXT" />
-
-        <format target="http://www.ietf.org/internet-drafts/draft-nandakumar-mmusic-sdp-mux-attributes-03.pdf"
-                type="PDF" />
+        
+        <seriesInfo name='Internet-Draft' value='draft-ietf-mmusic-sdp-mux-attributes-01' />
+        <format type='TXT'
+                target='http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdp-mux-attributes-01.txt' />
       </reference>
 
-      <!-- NORM 7 -->
 
       <!-- NORM 8 -->
 
@@ -2321,6 +2302,24 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
       <!-- NORM 15 -->
 
+      <reference anchor='RFC7022'>
+        <front>
+          <title>Guidelines for Choosing RTP Control Protocol (RTCP) Canonical Names (CNAMEs)</title>
+          <author initials='A.' surname='Begen' fullname='A. Begen'>
+          <organization /></author>
+          <author initials='C.' surname='Perkins' fullname='C. Perkins'>
+          <organization /></author>
+          <author initials='D.' surname='Wing' fullname='D. Wing'>
+          <organization /></author>
+          <author initials='E.' surname='Rescorla' fullname='E. Rescorla'>
+          <organization /></author>
+          <date year='2013' month='September' />
+        </front>
+
+        <seriesInfo name='RFC' value='7022' />
+        <format type='TXT' octets='21717' target='http://www.rfc-editor.org/rfc/rfc7022.txt' />
+      </reference>
+      
       <!-- NORM 16 -->
 
       <!-- NORM 17 -->


### PR DESCRIPTION
Just moved draft-rescorla-random-cname to RFC 7022 

and 

nandakumar-mmusic-sdp-mux-attributes to ietf-mmusic-sdp-mux-attributes
