### PR TITLE
Add bundled case to draft FEC doc

### DIFF
--- a/fec/draft-uberti-rtcweb-fec.txt
+++ b/fec/draft-uberti-rtcweb-fec.txt
@@ -1,0 +1,392 @@
+
+
+
+
+Network Working Group                                          J. Uberti
+Internet-Draft                                                    Google
+Intended status: Standards Track                        October 27, 2014
+Expires: April 30, 2015
+
+
+              WebRTC Forward Error Correction Requirements
+                       draft-uberti-rtcweb-fec-00
+
+Abstract
+
+   This document makes recommendations for how Forward Error Correction
+   (FEC) should be used by WebRTC applications.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on April 30, 2015.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 1]
+
+Internet-Draft                 WebRTC FEC                   October 2014
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   3.  Types of FEC  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     3.1.  Separate FEC Stream . . . . . . . . . . . . . . . . . . .   3
+     3.2.  Redundant Encoding  . . . . . . . . . . . . . . . . . . .   3
+     3.3.  Codec-Specific In-band FEC  . . . . . . . . . . . . . . .   3
+   4.  FEC for Audio Content . . . . . . . . . . . . . . . . . . . .   3
+     4.1.  Recommended Mechanism . . . . . . . . . . . . . . . . . .   3
+     4.2.  Negotiating Support . . . . . . . . . . . . . . . . . . .   4
+   5.  FEC for Video Content . . . . . . . . . . . . . . . . . . . .   4
+     5.1.  Recommended Mechanism . . . . . . . . . . . . . . . . . .   4
+     5.2.  Negotiating Support . . . . . . . . . . . . . . . . . . .   5
+   6.  Implementation Requirements . . . . . . . . . . . . . . . . .   5
+   7.  Adaptive Use of FEC . . . . . . . . . . . . . . . . . . . . .   5
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
+   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   5
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .   6
+     11.2.  Informative References . . . . . . . . . . . . . . . . .   6
+   Appendix A.  Change log . . . . . . . . . . . . . . . . . . . . .   6
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   6
+
+1.  Introduction
+
+   In situations where packet loss is high, or media quality must be
+   perfect, Forward Error Correction (FEC) can be used to proactively
+   recover from packet losses.  This document describes what FEC
+   mechanisms should be used by WebRTC client implementations.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+3.  Types of FEC
+
+   By its name, FEC describes the sending of redundant information in an
+   outgoing packet stream so that information can still be recovered
+   even in the face of packet loss.  There are multiple ways in which
+   this can be accomplished; this section enumerates the various
+   mechanisms and describes their tradeoffs.
+
+
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 2]
+
+Internet-Draft                 WebRTC FEC                   October 2014
+
+
+3.1.  Separate FEC Stream
+
+   This approach, as described in [RFC5956], Section 4.3, sends FEC
+   packets as an independent SSRC-multiplexed stream, with its own SSRC
+   and payload type.  While by far the most flexible, each FEC packet
+   will have its own IP+UDP+RTP+FEC header, leading to additional
+   overhead of the FEC stream.
+
+3.2.  Redundant Encoding
+
+   This approach, as descibed in [RFC2198], allows for redundant data to
+   be piggybacked on an existing primary encoding in a single packet.
+   This redundant data may be an exact copy of a previous packet, or for
+   codecs that support variable-bitrate encodings, possibly a smaller,
+   lower-quality representation.  Since there is only a single set of
+   packet headers, this allows for a very efficient representation of
+   primary + redundant data.  However, this savings is only realized
+   when the two encodings both fit into a single packet (i.e. less than
+   a MTU).  This approach is also only applicable to audio content.
+
+3.3.  Codec-Specific In-band FEC
+
+   Some audio codecs, notably Opus [RFC6716], support their own in-band
+   FEC mechanism, where FEC data is included in the codec payload.  In
+   the case of Opus specifically, packets deemed as important are re-
+   encoded at a lower bitrate and added to the subsequent packet,
+   allowing partial recovery of a lost packet.  See [RFC6716],
+   Section 2.1.7 for details.
+
+4.  FEC for Audio Content
+
+   The following section provides guidance on how to best use FEC for
+   transmitting audio data.  As indicated in Section 7 below, FEC should
+   only be activated if network conditions warrant it, or upon explicit
+   application request.
+
+4.1.  Recommended Mechanism
+
+   When using the Opus codec in its default (hybrid) mode, use of the
+   built-in Opus FEC mechanism is RECOMMENDED.  This provides reasonable
+   protection of the audio stream against typical losses, with moderate
+   overhead.  [TODO: add stats] Note though that this mechanism only
+   protects the SILK layer of the Opus codec; the CELT portion is not
+   protected.  This is not an issue when Opus is running in hybrid mode,
+   as the lower frequencies will still be able to be recovered, with
+   minimal quality impact.
+
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 3]
+
+Internet-Draft                 WebRTC FEC                   October 2014
+
+
+   When using Opus in CELT mode, or other variable-bitrate codecs, use
+   of [RFC2198] redundant encoding with a lower-fidelity version of the
+   previous packet is RECOMMENDED.  When using Opus specifically, the
+   lower-fidelity version can simply be a truncated version of the
+   previous Opus packet.  [TODO: decide exact truncated size] This
+   provides reasonable protection of the payload with minimal overhead.
+
+   When using constant-bitrate codecs, e.g.  PCMU, use of [RFC2198]
+   redundant encoding is NOT RECOMMENDED, as this will result in a
+   potentially significant bitrate increase.  Furthermore, suddenly
+   increasing the bitrate to deal with packet losses may actually make
+   things worse.
+
+   Because of the lower packet rate of audio encodings, usually a single
+   packet per frame, use of a separate FEC stream comes with a higher
+   overhead than other mechanisms, and therefore is NOT RECOMMENDED.
+
+4.2.  Negotiating Support
+
+   Support for redundant encoding can be indicated by offering "red" as
+   a supported payload type in the offer.  Answerers can reject the use
+   of redundant encoding by not including "red" as a supported payload
+   type in the answer.
+
+   Support for codec-specific FEC mechanisms are typically indicated via
+   "a=fmtp" parameters.  For Opus specifically, this is controlled by
+   the "useinbandfec=1" parameter, as specified in
+   [I-D.ietf-payload-rtp-opus].  These parameters are declarative and
+   can be negotiated separately for either media direction.
+
+5.  FEC for Video Content
+
+   The following section provides guidance on how to best use FEC for
+   transmitting video data.  As indicated in Section 7 below, FEC should
+   only be activated if network conditions warrant it, or upon explicit
+   application request.
+
+5.1.  Recommended Mechanism
+
+   For video content, use of a separate FEC stream with the RTP payload
+   format described in [I-D.singh-payload-rtp-1d2d-parity-scheme] is
+   RECOMMENDED.  The receiver can demultiplex the incoming FEC stream by
+   SSRC and correlate it with the primary stream via the ssrc-group
+   mechanism.
+
+   Note that this only allows the FEC stream to protect a single primary
+   stream.  Support for protecting multiple primary streams with a
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 4]
+
+Internet-Draft                 WebRTC FEC                   October 2014
+
+
+   single FEC stream is complicated by WebRTC's 1-m-line-per-stream
+   policy and requires further study.
+
+5.2.  Negotiating Support
+
+   To offer support for a separate FEC stream, the offerer MUST offer
+   one of the formats described in
+   [I-D.singh-payload-rtp-1d2d-parity-scheme], Section 5.1, as well as a
+   ssrc-group with "FEC-FR" semantics as described in [RFC5956],
+   Section 4.3.
+
+   Answerers can reject the use of FEC by not including FEC payloads in
+   the answer.
+
+6.  Implementation Requirements
+
+   To support the functionality recommended above, implementations MUST
+   support the redundant encoding mechanism described in [RFC2198] and
+   the FEC mechanism described in [RFC5956] and
+   [I-D.singh-payload-rtp-1d2d-parity-scheme].
+
+   Implementations MAY support additional FEC mechanisms if desired,
+   e.g.  [RFC5109].
+
+7.  Adaptive Use of FEC
+
+   Since use of FEC causes redundant data to be transmitted, this will
+   lead to less bandwidth available for the primary encoding, when in a
+   bandwidth-constrained environment.  Given this, WebRTC
+   implementations SHOULD only transmit FEC data when network conditions
+   indicate that this is advisable (e.g. by monitoring transmit packet
+   loss data from RTCP Receiver Reports), or the application indicates
+   it is willing to pay a quality penalty to proactively avoid losses.
+
+8.  Security Considerations
+
+   TODO
+
+9.  IANA Considerations
+
+   This document requires no actions from IANA.
+
+10.  Acknowledgements
+
+   Several people provided significant input into this document,
+   including Jonathan Lennox, Giri Mandyam, Varun Singh, Tim Terriberry,
+   and Mo Zanaty.
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 5]
+
+Internet-Draft                 WebRTC FEC                   October 2014
+
+
+11.  References
+
+11.1.  Normative References
+
+   [I-D.singh-payload-rtp-1d2d-parity-scheme]
+              Singh, V., Begen, A., and M. Zanaty, "RTP Payload Format
+              for Non-Interleaved and Interleaved Parity Forward Error
+              Correction (FEC)", draft-singh-payload-rtp-1d2d-parity-
+              scheme-00 (work in progress), October 2014.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2198]  Perkins, C., Kouvelas, I., Hodson, O., Hardman, V.,
+              Handley, M., Bolot, J., Vega-Garcia, A., and S. Fosse-
+              Parisis, "RTP Payload for Redundant Audio Data", RFC 2198,
+              September 1997.
+
+   [RFC5956]  Begen, A., "Forward Error Correction Grouping Semantics in
+              the Session Description Protocol", RFC 5956, September
+              2010.
+
+11.2.  Informative References
+
+   [I-D.ietf-payload-rtp-opus]
+              Spittka, J., Vos, K., and J. Valin, "RTP Payload Format
+              for Opus Speech and Audio Codec", draft-ietf-payload-rtp-
+              opus-03 (work in progress), July 2014.
+
+   [RFC5109]  Li, A., "RTP Payload Format for Generic Forward Error
+              Correction", RFC 5109, December 2007.
+
+   [RFC6716]  Valin, JM., Vos, K., and T. Terriberry, "Definition of the
+              Opus Audio Codec", RFC 6716, September 2012.
+
+Appendix A.  Change log
+
+   Changes in draft -00:
+
+   o  Initial version, from sidebar conversation at IETF 90.
+
+Author's Address
+
+
+
+
+
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 6]
+
+Internet-Draft                 WebRTC FEC                   October 2014
+
+
+   Justin Uberti
+   Google
+   747 6th Ave S
+   Kirkland, WA  98033
+   USA
+
+   Email: justin@uberti.name
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Uberti                   Expires April 30, 2015                 [Page 7]

--- a/fec/draft-uberti-rtcweb-fec.xml
+++ b/fec/draft-uberti-rtcweb-fec.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="US-ASCII"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
+<!ENTITY rfc2198 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2198.xml">
+<!ENTITY rfc5109 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5109.xml">
+<!ENTITY rfc5956 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5956.xml">
+<!ENTITY rfc6716 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6716.xml">
+<!ENTITY fecpayload SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.singh-payload-rtp-1d2d-parity-scheme.xml">
+<!ENTITY opuspayload SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-payload-rtp-opus.xml">
+]>
 <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
 <?rfc toc="yes" ?>
 <?rfc symrefs="yes" ?>
@@ -11,7 +19,7 @@
 <?rfc rfcedstyle="no" ?>
 <?rfc tocdepth="4"?>
 
-<rfc category="std" docName="draft-uberti-rtcweb-fec" ipr="trust200902">
+<rfc category="std" docName="draft-uberti-rtcweb-fec-00" ipr="trust200902">
   <front>
     <title abbrev="WebRTC FEC">WebRTC Forward Error Correction Requirements</title>
 
@@ -48,8 +56,8 @@
   <middle>
     <section title="Introduction">
       <t>In situations where packet loss is high, or media quality must be perfect,
-      Forward Error Correction (FEC) can be used to recover from packet losses.
-      This document describes what FEC mechanisms are to be used by WebRTC
+      Forward Error Correction (FEC) can be used to proactively recover from packet losses.
+      This document describes what FEC mechanisms should be used by WebRTC
       client implementations.</t>
     </section>
 
@@ -67,38 +75,120 @@
          can be accomplished; this section enumerates the various mechanisms
          and describes their tradeoffs.</t>
       <section title="Separate FEC Stream">
-          <t>This approach, 
-
+          <t>This approach, as described in <xref target="RFC5956"/>, Section 4.3, sends FEC packets as an 
+            independent SSRC-multiplexed stream, with its own SSRC and payload type.
+            While by far the most flexible, each FEC packet will have its own
+            IP+UDP+RTP+FEC header, leading to additional overhead of the FEC stream.
           </t>
       </section>
       <section title="Redundant Encoding">
+          <t>This approach, as descibed in <xref target="RFC2198"/>, allows for redundant data
+            to be piggybacked on an existing primary encoding in a single packet.
+            This redundant data may be an exact copy of a previous packet, or
+            for codecs that support variable-bitrate encodings, possibly a smaller,
+            lower-quality representation. Since there is only a single set of
+            packet headers, this allows for a very efficient representation of
+            primary + redundant data. However, this savings is only realized when
+            the two encodings both fit into a single packet (i.e. less than a MTU).
+            This approach is also only applicable to audio content.
+          </t>
       </section>
        <section title="Codec-Specific In-band FEC">
+          <t>Some audio codecs, notably Opus <xref target="RFC6716"/>, support their own in-band FEC
+            mechanism, where FEC data is included in the codec payload. In the
+            case of Opus specifically, packets deemed as important are re-encoded
+            at a lower bitrate and added to the subsequent packet, allowing partial
+            recovery of a lost packet. See <xref target="RFC6716"/>, Section 2.1.7 for details.
+          </t>
       </section>
     </section>
 
     <section title="FEC for Audio Content">
+      <t>The following section provides guidance on how to best use FEC for transmitting 
+      audio data. As indicated in <xref target="adaptive-fec"/> below, FEC should only
+      be activated if network conditions warrant it, or upon explicit application request.
+      </t>
       <section title="Recommended Mechanism">
+        <t>When using the Opus codec in its default (hybrid) mode, use of
+          the built-in Opus FEC mechanism is RECOMMENDED.
+          This provides reasonable protection of the
+          audio stream against typical losses, with moderate overhead. [TODO: add stats]
+          Note though that this mechanism only protects the SILK layer of the Opus codec;
+          the CELT portion is not protected. This is not an issue when Opus is running in 
+          hybrid mode, as the lower frequencies will still be able to be recovered,
+          with minimal quality impact.
+        </t>
+        <t>When using Opus in CELT mode, or other variable-bitrate codecs,
+        use of <xref target="RFC2198"/> redundant encoding with a lower-fidelity version of the
+        previous packet is RECOMMENDED. When using Opus specifically, the lower-fidelity
+        version can simply be a truncated version of the previous Opus packet.
+        [TODO: decide exact truncated size]
+        This provides reasonable protection of the payload with minimal overhead.
+        </t>
+        <t>When using constant-bitrate codecs, e.g. PCMU, use of <xref target="RFC2198"/> redundant encoding
+        is NOT RECOMMENDED, as this will result in a potentially significant bitrate increase.
+        Furthermore, suddenly increasing the bitrate to deal with packet losses may
+        actually make things worse.
+        </t>
+        <t>Because of the lower packet rate of audio encodings, usually a single packet per
+        frame, use of a separate FEC stream comes with a higher overhead than other
+        mechanisms, and therefore is NOT RECOMMENDED.
+        </t>
       </section>
+
       <section title="Negotiating Support">
+        <t>Support for redundant encoding can be indicated by offering "red" as a
+        supported payload type in the offer. Answerers can reject the use of
+        redundant encoding by not including "red" as a supported payload type in 
+        the answer.</t>
+        <t>Support for codec-specific FEC mechanisms are typically indicated via
+        "a=fmtp" parameters. For Opus specifically, this is controlled by the
+        "useinbandfec=1" parameter, as specified in <xref target="I-D.ietf-payload-rtp-opus"/>.
+        These parameters are declarative and can
+        be negotiated separately for either media direction.</t>
       </section>
-     Single SSRC; RFC2198. Opus inband fec (not CELT)
-        Offer offers RED; answerer can disable by rejecting RED
-        Partial packets - only Opus 
     </section>
 
     <section title="FEC for Video Content">
+      <t>The following section provides guidance on how to best use FEC for transmitting 
+      video data. As indicated in <xref target="adaptive-fec"/> below, FEC should only
+      be activated if network conditions warrant it, or upon explicit application request.
+      </t>
       <section title="Recommended Mechanism">
+        <t>For video content, use of a separate FEC stream with the RTP payload format
+        described in <xref target="I-D.singh-payload-rtp-1d2d-parity-scheme"/> is RECOMMENDED.
+        The receiver can demultiplex the incoming FEC stream by SSRC and correlate it
+        with the primary stream via the ssrc-group mechanism.
+        </t>
+        <t>Note that this only allows the FEC stream to protect a single primary stream.
+        Support for protecting multiple primary streams with a single FEC stream is
+        complicated by WebRTC's 1-m-line-per-stream policy and requires further study.</t>
       </section>
       <section title="Negotiating Support">
-      </section>
-      <t>Transmit on separate SSRC
-        negotiate that SSRC with ssrc-group and FEC semantics
-        details in payload-singh-fec
-        protect one flow at a time
+        <t>To offer support for a separate FEC stream, the offerer MUST offer one of
+        the formats described in <xref target="I-D.singh-payload-rtp-1d2d-parity-scheme"/>, Section 5.1, as well as a
+        ssrc-group with "FEC-FR" semantics as described in <xref target="RFC5956"/>, Section 4.3.</t>
+        <t>Answerers can reject the use of FEC by not including FEC payloads in the answer.</t>
+      </section>   
+    </section>
+
+    <section title="Implementation Requirements">
+        <t>To support the functionality recommended above, implementations MUST support
+        the redundant encoding mechanism described in <xref target="RFC2198"/> and the FEC 
+        mechanism described in <xref target="RFC5956"/> and <xref target="I-D.singh-payload-rtp-1d2d-parity-scheme"/>.</t>
+        <t>Implementations MAY support additional FEC mechanisms if desired, 
+        e.g. <xref target="RFC5109"/>.</t>
+    </section>
+    
+    <section anchor="adaptive-fec" title="Adaptive Use of FEC">
+      <t>Since use of FEC causes redundant data to be transmitted, this will 
+        lead to less bandwidth available for the primary encoding, when in a
+        bandwidth-constrained environment. Given this, WebRTC implementations
+        SHOULD only transmit FEC data when network conditions indicate that
+        this is advisable (e.g. by monitoring transmit packet loss data from
+        RTCP Receiver Reports), or the application indicates it is willing to
+        pay a quality penalty to proactively avoid losses.
       </t>
-      
-      
     </section>
 
     <section title="Security Considerations">
@@ -110,17 +200,28 @@
     </section>
 
     <section title="Acknowledgements">
+      <t>Several people provided significant input into this document, including Jonathan Lennox, Giri Mandyam, Varun Singh, Tim Terriberry, and Mo Zanaty.</t>
     </section>
   </middle>
 
   <back>
     <references title="Normative References">
+      &rfc2119;
+      &rfc2198;
+      &rfc5956;
+      &fecpayload;
     </references>
 
     <references title="Informative References">
+      &rfc5109;
+      &rfc6716;
+      &opuspayload;
     </references>
 
     <section title="Change log">
+      <t>Changes in draft -00: <list style="symbols">
+        <t>Initial version, from sidebar conversation at IETF 90.</t>
+      </list></t>
     </section>
   </back>
 </rfc>

--- a/nombis/Makefile
+++ b/nombis/Makefile
@@ -1,0 +1,41 @@
+
+
+SRC  := $(wildcard draft-*.xml)
+WSRC  := $(wildcard *.wsd)
+
+HTML := $(patsubst %.xml,%.html,$(SRC))
+TXT  := $(patsubst %.xml,%.txt,$(SRC))
+DIF  := #$(patsubst %.xml,%.diff.html,$(SRC))
+PDF  := #$(patsubst %.xml,%.pdf,$(SRC))
+SVG  := #$(patsubst %.wsd,%.svg,$(WSRC))
+
+#all: $(HTML) $(TXT) $(DIF) $(PDF)
+all: $(HTML) $(TXT) $(DIF) $(SVG) $(PDF)
+
+clean:
+	rm -f *~ draft*.html draft*pdf draft-*txt $(SVG)
+
+#%.html: %.xml
+#	xsltproc -o $@ rfc2629.xslt $^
+
+%.html: %.xml
+	xml2rfc --html $^ -o $@
+
+
+%.txt: %.xml
+	xml2rfc --text $^ -o $@
+
+%.diff.html: %.txt.old %.txt 
+	htmlwdiff  $^ >  $@
+
+%.pdf: %.html  $(SVG)
+	wkpdf -p letter -s $^ -o $@
+
+%.svg: %.wsd
+	node ~/bin/ladder.js $^ $@
+
+%.png: %.svg
+	java -jar batik-rasterizer.jar $^ -d $@ -bg 255.255.255.255
+
+
+

--- a/nombis/draft-uberti-mmusic-nombis.html
+++ b/nombis/draft-uberti-mmusic-nombis.html
@@ -1,0 +1,655 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://dublincore.org/documents/2008/08/04/dc-html/">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index,nofollow" />
+    <meta name="creator" content="rfcmarkup version 1.109" />
+    <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
+
+    <link rel="icon" href="" type="image/png" />
+    <link rel="shortcut icon" href="" type="image/png" />
+    <title>draft-uberti-mmusic-nombis-2.txt - Improvements to ICE Candidate Nomination</title>
+    
+    
+    <style type="text/css">
+	body {
+	    margin: 0px 8px;
+            font-size: 1em;
+	}
+        h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+	    font-weight: bold;
+            line-height: 0pt;
+            display: inline;
+            white-space: pre;
+            font-family: monospace;
+            font-size: 1em;
+	    font-weight: bold;
+        }
+        pre {
+            font-size: 1em;
+            margin-top: 0px;
+            margin-bottom: 0px;
+        }
+	.pre {
+	    white-space: pre;
+	    font-family: monospace;
+	}
+	.header{
+	    font-weight: bold;
+	}
+        .newpage {
+            page-break-before: always;
+        }
+        .invisible {
+            text-decoration: none;
+            color: white;
+        }
+        a.selflink {
+          color: black;
+          text-decoration: none;
+        }
+        @media print {
+            body {
+                font-family: monospace;
+                font-size: 10.5pt;
+            }
+            h1, h2, h3, h4, h5, h6 {
+                font-size: 1em;
+            }
+        
+            a:link, a:visited {
+                color: inherit;
+                text-decoration: none;
+            }
+            .noprint {
+                display: none;
+            }
+        }
+	@media screen {
+	    .grey, .grey a:link, .grey a:visited {
+		color: #777;
+	    }
+            .docinfo {
+                background-color: #EEE;
+            }
+            .top {
+                border-top: 7px solid #EEE;
+            }
+            .bgwhite  { background-color: white; }
+            .bgred    { background-color: #F44; }
+            .bggrey   { background-color: #666; }
+            .bgbrown  { background-color: #840; }            
+            .bgorange { background-color: #FA0; }
+            .bgyellow { background-color: #EE0; }
+            .bgmagenta{ background-color: #F4F; }
+            .bgblue   { background-color: #66F; }
+            .bgcyan   { background-color: #4DD; }
+            .bggreen  { background-color: #4F4; }
+
+            .legend   { font-size: 90%; }
+            .cplate   { font-size: 70%; border: solid grey 1px; }
+	}
+    </style>
+    <!--[if IE]>
+    <style>
+    body {
+       font-size: 13px;
+       margin: 10px 10px;
+    }
+    </style>
+    <![endif]-->
+
+    <script type="text/javascript"><!--
+    function addHeaderTags() {
+	var spans = document.getElementsByTagName("span");
+	for (var i=0; i < spans.length; i++) {
+	    var elem = spans[i];
+	    if (elem) {
+		var level = elem.getAttribute("class");
+                if (level == "h1" || level == "h2" || level == "h3" || level == "h4" || level == "h5" || level == "h6") {
+                    elem.innerHTML = "<"+level+">"+elem.innerHTML+"</"+level+">";		
+                }
+	    }
+	}
+    }
+    var legend_html = "Colour legend:<br />      <table>         <tr><td>Unknown:</td>                   <td><span class='cplate bgwhite'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Draft:</td>                     <td><span class='cplate bgred'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Informational:</td>             <td><span class='cplate bgorange'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Experimental:</td>              <td><span class='cplate bgyellow'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Best Common Practice:</td>      <td><span class='cplate bgmagenta'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Proposed Standard:</td>         <td><span class='cplate bgblue'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Draft Standard (old designation):</td> <td><span class='cplate bgcyan'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Internet Standard:</td>         <td><span class='cplate bggreen'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Historic:</td>                  <td><span class='cplate bggrey'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>         <tr><td>Obsolete:</td>                  <td><span class='cplate bgbrown'>&nbsp;&nbsp;&nbsp;&nbsp;</span></td></tr>     </table>";
+    function showElem(id) {
+        var elem = document.getElementById(id);
+        elem.innerHTML = eval(id+"_html");
+        elem.style.visibility='visible';
+    }
+    function hideElem(id) {
+        var elem = document.getElementById(id);
+        elem.style.visibility='hidden';        
+        elem.innerHTML = "";
+    }
+    // -->
+    </script>
+</head>
+<body onload="addHeaderTags()">
+   <div style="height: 13px;">
+      <div onmouseover="this.style.cursor='pointer';"
+         onclick="showElem('legend');"
+         onmouseout="hideElem('legend')"
+	 style="height: 6px; position: absolute;"
+         class="pre noprint docinfo "
+         title="Click for colour legend." >                                                                        </div>
+      <div id="legend"
+           class="docinfo noprint pre legend"
+           style="position:absolute; top: 4px; left: 4ex; visibility:hidden; background-color: white; padding: 4px 9px 5px 7px; border: solid #345 1px; "
+           onmouseover="showElem('legend');"
+           onmouseout="hideElem('legend');">
+      </div>
+   </div>
+
+<span class="pre noprint docinfo">                                                                        </span><br />
+<span class="pre noprint docinfo">                                                                        </span><br />
+<span class="pre noprint docinfo">                                                                        </span><br />
+<pre>
+Network Working Group                                          J. Uberti
+Internet-Draft                                                    Google
+Intended status: Standards Track                               J. Lennox
+Expires: May 10, 2015                                              Vidyo
+                                                       November 06, 2014
+
+
+                <span class="h1">Improvements to ICE Candidate Nomination</span>
+                     <span class="h1">draft-uberti-mmusic-nombis-00</span>
+
+Abstract
+
+   This document makes recommendations for simplifying and improving the
+   procedures for candidate nomination in Interactive Connectivity
+   Establishment (ICE).
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?bcp=78">BCP 78</a> and <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?bcp=79">BCP 79</a>.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at <a href="http://datatracker.ietf.org/drafts/current/">http://datatracker.ietf.org/drafts/current/</a>.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on May 10, 2015.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?bcp=78">BCP 78</a> and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (<a href="http://trustee.ietf.org/license-info">http://trustee.ietf.org/license-info</a>) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in <a href="#section-4">Section 4</a>.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 1]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-2" id="page-2" href="#page-2" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+Table of Contents
+
+   <a href="#section-1">1</a>.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-2">2</a>
+   <a href="#section-2">2</a>.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-3">3</a>
+   <a href="#section-3">3</a>.  Goals and Requirements  . . . . . . . . . . . . . . . . . . .   <a href="#page-3">3</a>
+     <a href="#section-3.1">3.1</a>.  Minimize Call Setup Latency . . . . . . . . . . . . . . .   <a href="#page-3">3</a>
+     <a href="#section-3.2">3.2</a>.  Allow Controlling Endpoint to Make Dynamic Decisions  . .   <a href="#page-3">3</a>
+     3.3.  Allow Selected Pair Change At Any Time Without Signaling    4
+     <a href="#section-3.4">3.4</a>.  Allow Continuous Addition of Candidates . . . . . . . . .   <a href="#page-4">4</a>
+     <a href="#section-3.5">3.5</a>.  Maintain Backwards Compatibility  . . . . . . . . . . . .   <a href="#page-4">4</a>
+     <a href="#section-3.6">3.6</a>.  Minimize Complexity Increase  . . . . . . . . . . . . . .   <a href="#page-5">5</a>
+   <a href="#section-4">4</a>.  Deprecating Aggressive Nomination . . . . . . . . . . . . . .   <a href="#page-5">5</a>
+     <a href="#section-4.1">4.1</a>.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-5">5</a>
+     <a href="#section-4.2">4.2</a>.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-5">5</a>
+     <a href="#section-4.3">4.3</a>.  Backwards Compatibility . . . . . . . . . . . . . . . . .   <a href="#page-6">6</a>
+   <a href="#section-5">5</a>.  Introducing Continuous Nomination . . . . . . . . . . . . . .   <a href="#page-6">6</a>
+     <a href="#section-5.1">5.1</a>.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-6">6</a>
+     <a href="#section-5.2">5.2</a>.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-7">7</a>
+     <a href="#section-5.3">5.3</a>.  Backwards Compatibility . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+   <a href="#section-6">6</a>.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+   <a href="#section-7">7</a>.  Security Considerations . . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+   <a href="#section-8">8</a>.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+   <a href="#section-9">9</a>.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+   <a href="#section-10">10</a>. References  . . . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+     <a href="#section-10.1">10.1</a>.  Normative References . . . . . . . . . . . . . . . . . .   <a href="#page-8">8</a>
+     <a href="#section-10.2">10.2</a>.  Informative References . . . . . . . . . . . . . . . . .   <a href="#page-9">9</a>
+   <a href="#appendix-A">Appendix A</a>.  Change log . . . . . . . . . . . . . . . . . . . . .   <a href="#page-9">9</a>
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   <a href="#page-9">9</a>
+
+<span class="h2"><a class="selflink" name="section-1" href="#section-1">1</a>.  Introduction</span>
+
+   Interactive Connectivity Establishment (ICE) attempts to find the
+   'best' path for connectivity between two peers; in ICE parlance,
+   these paths are known as 'candidate pairs'.  During the ICE process,
+   one endpoint, known as the 'controlling' endpoint, selects a
+   candidate pair as the best pair; this action is known as nomination.
+   ICE supports two different mechanisms for performing nomination,
+   known as Regular Nomination, and Aggressive Nomination.
+
+   However, each of these modes have flaws that restrict their
+   usefulness.  Regular Nomination, as currently speced, requires a best
+   pair to be chosen before media transmission can start, causing
+   unnecessary call setup delay.  Aggressive Nomination, while avoiding
+   this delay, gives the controlling endpoint much less discretion into
+   which candidate pair is chosen, preventing it from making decisions
+   based on dynamic factors such as RTT or loss rate.  Needless to say,
+   the presence of both modes also adds nontrivial complexity.
+
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 2]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-3" id="page-3" href="#page-3" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+   Lastly, ICE is currently defined as a finite process, where the
+   decision on the optimal candidate pair is made during call setup and
+   infrequently (if ever) changed.  While this may be acceptable for
+   endpoints with static network configurations, it fails to meet the
+   needs of mobile endpoints, who may need to seamlessly move between
+   networks, or be connected to multiple networks simultaneously.  In
+   these cases, the controlling endpoint may want to maintain multiple
+   potential candidate pairs, and make dynamic decisions to switch
+   between them as conditions change.
+
+   To address these challenges, this document makes two proposals for
+   refactoring ICE nomination - merging Regular and Aggressive
+   Nomination, and introducing a new mode, known as Continuous
+   Nomination.  This makes ICE substantially more flexible without
+   increasing complexity.
+
+<span class="h2"><a class="selflink" name="section-2" href="#section-2">2</a>.  Terminology</span>
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [<a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=2119" title="&quot;Key words for use in RFCs to Indicate Requirement Levels&quot;">RFC2119</a>].
+
+<span class="h2"><a class="selflink" name="section-3" href="#section-3">3</a>.  Goals and Requirements</span>
+
+   The goals for improved ICE nomination are enumerated below.
+
+<span class="h3"><a class="selflink" name="section-3.1" href="#section-3.1">3.1</a>.  Minimize Call Setup Latency</span>
+
+   Modern ICE agents will often have multiple network interfaces and
+   multiple servers from which to obtain ICE candidates.  While some ICE
+   checks may succeed quickly, finishing the entire set of checks can
+   easily take multiple seconds; this concern is discussed in <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245#section-8.1.1.1">[RFC5245],
+   Section&nbsp;8.1.1.1</a>.  As a result, ICE endpoints MUST be able to start
+   transmitting media immediately upon a successful ICE check, and MUST
+   retain the ability to switch if a better candidate pair becomes
+   available later.
+
+<span class="h3"><a class="selflink" name="section-3.2" href="#section-3.2">3.2</a>.  Allow Controlling Endpoint to Make Dynamic Decisions</span>
+
+   While an ICE endpoint will assign various priority values to its ICE
+   candidates, these priorities are static and can only be based on a
+   priori knowledge; the shortcomings of this approach are discussed in
+   the first paragraph of <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245#section-2.6">Section&nbsp;2.6 in [RFC5245]</a>.  To properly make
+   choices in multi-network and multi-server scenarios, the controlling
+   endpoint MUST be able to make dynamic decisions about the selected
+   candidate pair based on observed network performance.  For example,
+   RTT could be used to evaluate which TURN servers to use, as described
+   in [<a href="#ref-I-D.williams-peer-redirect">I-D.williams-peer-redirect</a>] To ensure symmetric flows, this
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 3]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-4" id="page-4" href="#page-4" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+   implies that the controlling endpoint MUST be able to communicate its
+   choice to the controlled side.
+
+<span class="h3"><a class="selflink" name="section-3.3" href="#section-3.3">3.3</a>.  Allow Selected Pair Change At Any Time Without Signaling</span>
+
+   Expanding on the requirement above, the need to make dynamic
+   decisions is not limited to call setup.  A multihomed endpoint may
+   need to switch interfaces based on mobility considerations, or a
+   robust endpoint may want to keep multiple network paths warm and
+   switch immediately if connectivity is interrupted on one of them.  As
+   the signaling channel may be affected by the event necessitating the
+   switch, this implies that the controlling endpoint MUST be able to
+   change the selected pair and indicate this to the remote side without
+   signaling.  The need for this functionality has been stated in
+   [<a href="#ref-I-D.wing-mmusic-ice-mobility">I-D.wing-mmusic-ice-mobility</a>] and [<a href="#ref-I-D.singh-avtcore-mprtp">I-D.singh-avtcore-mprtp</a>].
+
+   The rules in [<a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245" title="&quot;Interactive Connectivity Establishment (ICE): A Protocol for Network Address Translator (NAT) Traversal for Offer/Answer Protocols&quot;">RFC5245</a>] ensure that the controlled endpoint keeps its
+   candidate needed for the selected pair alive.  However, in order for
+   alternate pairs to remain available, the controlled endpoint must
+   keep the associated candidates alive as well, following the
+   procedures outlined in <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245#section-4.1.1.4">[RFC5245], Section&nbsp;4.1.1.4</a>.  This implies that
+   the controlling endpoint MUST have some way to indicate to the
+   controlled side that specific candidates are to be kept alive.
+
+<span class="h3"><a class="selflink" name="section-3.4" href="#section-3.4">3.4</a>.  Allow Continuous Addition of Candidates</span>
+
+   In certain network mobility scenarios, networks may come up and down
+   while the call is active.  In order to allow candidates gathered on
+   newly available networks to be used for the selected pair or backup
+   pairs, the endpoint MUST be able to gather candidates on these
+   networks and communicate them to the remote side.  While this could
+   be done using an ICE restart, as described in <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245#section-9.1">[RFC5245], Section&nbsp;9.1</a>,
+   the ICE restart may have unintended consequences, such as causing the
+   remote side to regather all candidates.  Instead, it would be best if
+   the new candidates could be trickled, as discussed in
+   [<a href="#ref-I-D.ietf-mmusic-trickle-ice">I-D.ietf-mmusic-trickle-ice</a>], but even after ICE processing has
+   completed.
+
+<span class="h3"><a class="selflink" name="section-3.5" href="#section-3.5">3.5</a>.  Maintain Backwards Compatibility</span>
+
+   To prevent interoperability problems, ICE endpoints that support the
+   functionality listed above MUST still maintain [<a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245" title="&quot;Interactive Connectivity Establishment (ICE): A Protocol for Network Address Translator (NAT) Traversal for Offer/Answer Protocols&quot;">RFC5245</a>] compliance
+   when interacting with existing endpoints.  However, the ideal
+   solution SHOULD allow some improvements to occur when only the
+   controlling side supports the new functionality.
+
+
+
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 4]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-5" id="page-5" href="#page-5" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+<span class="h3"><a class="selflink" name="section-3.6" href="#section-3.6">3.6</a>.  Minimize Complexity Increase</span>
+
+   Increased functionality typically leads to increased complexity,
+   which leads to more edge cases, and more implementation bugs.  This
+   suggests that in addition to proposing new ICE functionality, the
+   ideal solution SHOULD deprecate superfluous functionality.
+
+<span class="h2"><a class="selflink" name="section-4" href="#section-4">4</a>.  Deprecating Aggressive Nomination</span>
+
+<span class="h3"><a class="selflink" name="section-4.1" href="#section-4.1">4.1</a>.  Overview</span>
+
+   The main benefits of Regular Nomination are that the controlling side
+   can dynamically choose which candidate pair to use, and a clear
+   signal when the nomination process has completed, via the presence of
+   the USE-CANDIDATE flag in a Binding Request.  The main benefit of
+   Aggressive Nomination is that it is only necessary to send a single
+   Binding Request before starting the transmission of media, reducing
+   setup latency.  Why don't we have both?
+
+   By preserving the dynamic behavior of Regular Nomination, but
+   allowing media transmission to start upon a single successful
+   connectivity check, as in Aggressive Nomination, the requirements of
+   <a href="#section-3.1">Section 3.1</a> and <a href="#section-3.2">Section 3.2</a> can be met, while meeting the
+   compatibility requirement from <a href="#section-3.5">Section 3.5</a> and, since Aggressive
+   Nomination is no longer needed, the complexity requirement from
+   <a href="#section-3.6">Section 3.6</a>.
+
+<span class="h3"><a class="selflink" name="section-4.2" href="#section-4.2">4.2</a>.  Operation</span>
+
+   Since media may be transmitted as soon as all components have a valid
+   pair, as indicated in [<a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245" title="&quot;Interactive Connectivity Establishment (ICE): A Protocol for Network Address Translator (NAT) Traversal for Offer/Answer Protocols&quot;">RFC5245</a>], Page 69, an ICE Agent can begin
+   transmitting media as soon as this occurs, even if it has not sent a
+   Binding Request with USE-CANDIDATE.
+
+   This pair can change as more pairs are added to the Valid list on the
+   controlling side.  When nomination completes, and a final pair is
+   selected, this is communicated to the controlled side via the typical
+   Binding Request with USE-CANDIDATE.
+
+   On the controlled side, the same process can occur, with the ICE
+   Agent transmitting media as soon as a valid pair exists.  To
+   encourage use of symmetric RTP, the controlled ICE Agent SHOULD use
+   the same candidate pair on which it received media from the
+   controlling side.  [Doesn't need to be secure media, since the
+   controlling side will finalize this preference through USE-CANDIDATE
+   shortly.]
+
+
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 5]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-6" id="page-6" href="#page-6" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+   As this is legal ICE behavior, no negotiation of this mechanism
+   should be needed.  In the event the receiver drops any packets that
+   arrive before a Binding Request with USE-CANDIDATE set, this will
+   simply lead to brief media clipping and will resolve itself once
+   nomination completes.
+
+<span class="h3"><a class="selflink" name="section-4.3" href="#section-4.3">4.3</a>.  Backwards Compatibility</span>
+
+   When acting in the controlled role, new implementations MUST NOT use
+   Aggressive Nomination.
+
+   When acting in the controlled role, and the controlling side is using
+   Aggressive Nomination (e.g. sending USE-CANDIDATE in its initial
+   Binding Requests), the standard PRIORITY-based mechanism outlined in
+   <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245#section-8.1.1.2">[RFC5245], Section&nbsp;8.1.1.2</a> should be used to determine the reverse
+   media path.
+
+   Note that if implementations would prefer to just avoid Aggressive
+   Nomination altogether, they MAY indicate some TBD pseudo-option in
+   the ice-options attribute.  Because compliant implementations MUST
+   NOT use Aggressive Nomination if an unknown ICE option is
+   encountered, this effectively prohibits the use of Aggressive
+   Nomination.  [N.B. this could be the ice-options:continuous option
+   described below]
+
+<span class="h2"><a class="selflink" name="section-5" href="#section-5">5</a>.  Introducing Continuous Nomination</span>
+
+<span class="h3"><a class="selflink" name="section-5.1" href="#section-5.1">5.1</a>.  Overview</span>
+
+   As discussed above, in mobile environments there can be multiple
+   possible valid candidate pairs, and these can change at various
+   points in the call, as new interfaces go up and down, signal strength
+   for wireless interfaces changes, and new relay servers are
+   discovered.
+
+   However, under 5245 rules, once a candidate pair is selected and
+   confirmed, via USE-CANDIDATE, nomination has completed and cannot be
+   restarted without performing an ICE restart.  This is overly complex
+   in many cases, and especially problematic in some specific ones,
+   namely a wifi-cellular handover, where the signaling path for
+   communicating an ICE restart may be impacted by the handover.
+
+   To address this situation, this section introduces the concept of
+   "continuous nomination", where the controlling ICE endpoint can
+   adjust the selected candidate pair at any time.  By allowing ICE
+   processing to occur continuously during a call, rather than just at
+   call setup, the requirements expressed in <a href="#section-3.3">Section 3.3</a> and <a href="#section-3.4">Section 3.4</a>
+   can be met.
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 6]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-7" id="page-7" href="#page-7" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+<span class="h3"><a class="selflink" name="section-5.2" href="#section-5.2">5.2</a>.  Operation</span>
+
+   Under continuous nomination, ICE never concludes; new candidates can
+   always be trickled, and a new candidate pair can be selected by the
+   controlling side at any time.
+
+   When selecting a new candidate pair, the controlling side informs the
+   controlled side of the chosen pat by sending a new Binding Request
+   with a USE-CANDIDATE attribute.  The decision about which candidate
+   pair to use is fully dynamic; the controlling side can use metrics
+   such as RTT or loss rate to change the selected pair at any time.  If
+   Binding Requests need to be sent for any other reason, such as
+   consent checks [TODO: reference], any checks sent on the selected
+   pair MUST include a USE-CANDIDATE attribute.
+
+   Upon receipt of a Binding Request with USE-CANDIDATE, the controlled
+   side MUST switch its media path to the candidate pair on which the
+   Binding Request was received.
+
+   During continuous nomination, the controlling side may still elect to
+   prune certain candidate pairs; for example, an implementation may
+   choose to drop relay candidates once a successful connection has been
+   established.  The controlled side, however, should follow the
+   controlling side's lead in terms of deciding whether any pairs should
+   be pruned.  The controlling ICE Agent informs the remote side of its
+   preferences by continuing to send Binding Requests to the remote side
+   on each candidate pair that it wants to retain.  The controlled ICE
+   Agent SHOULD prune any candidate pairs that have not received a
+   Binding Request in N seconds (30?), and SHOULD NOT keep alive any
+   candidates that are not associated with a live candidate pair.
+   [TODO: decide if this implicit timeout approach is correct, or if we
+   should have some sort of approach similar to TURN LIFETIME indicating
+   when a pair should be GCed, with LIFETIME==0 indicating immediate
+   GC.]  One side benefit of doing this is that the continuous exchange
+   of Binding Requests across all candidate pairs allows the RTT and
+   loss rate for each to be reliably determined and kept up to date.
+
+   If the endpoints have negotiated Trickle ICE support [TODO:
+   reference], and new candidates become available on either side, the
+   endpoint may send these candidates to the remote side using the
+   existing Trickle ICE mechanisms.  Once all of the new candidates have
+   been transmitted, the endpoint MUST send an end-of-candidates
+   messages, which indicates that no more candidates will be sent in the
+   near future.
+
+   At any point, either side may perform an ICE restart, which will
+   result in both sides gathering new ICE candidates, starting a new
+
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 7]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-8" id="page-8" href="#page-8" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+   continuous nomination sequence, and upon successful completion,
+   discarding all candidates from the previous nomination sequence.
+
+<span class="h3"><a class="selflink" name="section-5.3" href="#section-5.3">5.3</a>.  Backwards Compatibility</span>
+
+   Since standard ICE implementations may not expect the selected pair
+   to change after a USE-CANDIDATE attribute is received, support for
+   continuous nomination is explicitly indicated via a new "continuous"
+   value for ice-options.  If the remote side does not support the
+   "continuous" option, the controlling side MUST fall back to Regular
+   Nomination, as specified in [<a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245" title="&quot;Interactive Connectivity Establishment (ICE): A Protocol for Network Address Translator (NAT) Traversal for Offer/Answer Protocols&quot;">RFC5245</a>], Sectiom 8.1.1.
+
+<span class="h2"><a class="selflink" name="section-6" href="#section-6">6</a>.  Examples</span>
+
+   TODO
+
+<span class="h2"><a class="selflink" name="section-7" href="#section-7">7</a>.  Security Considerations</span>
+
+   TODO
+
+<span class="h2"><a class="selflink" name="section-8" href="#section-8">8</a>.  IANA Considerations</span>
+
+   A new ICE option "continuous" has been [will be] registered in the
+   "ICE Options" registry created by [<a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=6336" title="&quot;IANA Registry for Interactive Connectivity Establishment (ICE) Options&quot;">RFC6336</a>].
+
+<span class="h2"><a class="selflink" name="section-9" href="#section-9">9</a>.  Acknowledgements</span>
+
+   Several people provided significant input into this document,
+   including Martin Thomson, Brandon Williams, and Dan Wing.
+
+<span class="h2"><a class="selflink" name="section-10" href="#section-10">10</a>.  References</span>
+
+<span class="h3"><a class="selflink" name="section-10.1" href="#section-10.1">10.1</a>.  Normative References</span>
+
+   [<a name="ref-RFC2119" id="ref-RFC2119">RFC2119</a>]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?bcp=14">BCP 14</a>, <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=2119">RFC 2119</a>, March 1997.
+
+   [<a name="ref-RFC5245" id="ref-RFC5245">RFC5245</a>]  Rosenberg, J., "Interactive Connectivity Establishment
+              (ICE): A Protocol for Network Address Translator (NAT)
+              Traversal for Offer/Answer Protocols", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=5245">RFC 5245</a>, April
+              2010.
+
+   [<a name="ref-RFC6336" id="ref-RFC6336">RFC6336</a>]  Westerlund, M. and C. Perkins, "IANA Registry for
+              Interactive Connectivity Establishment (ICE) Options", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=6336">RFC</a>
+              <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?rfc=6336">6336</a>, July 2011.
+
+
+
+
+
+
+<span class="grey">Uberti &amp; Lennox           Expires May 10, 2015                  [Page 8]</span>
+</pre><!--NewPage--><pre class='newpage'><a name="page-9" id="page-9" href="#page-9" class="invisible"> </a>
+<span class="grey">Internet-Draft                   IceNom                    November 2014</span>
+
+
+<span class="h3"><a class="selflink" name="section-10.2" href="#section-10.2">10.2</a>.  Informative References</span>
+
+   [<a name="ref-I-D.ietf-mmusic-trickle-ice" id="ref-I-D.ietf-mmusic-trickle-ice">I-D.ietf-mmusic-trickle-ice</a>]
+              Ivov, E., Rescorla, E., and J. Uberti, "Trickle ICE:
+              Incremental Provisioning of Candidates for the Interactive
+              Connectivity Establishment (ICE) Protocol", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-ietf-mmusic-trickle-ice-01">draft-ietf-</a>
+              <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-ietf-mmusic-trickle-ice-01">mmusic-trickle-ice-01</a> (work in progress), February 2014.
+
+   [<a name="ref-I-D.singh-avtcore-mprtp" id="ref-I-D.singh-avtcore-mprtp">I-D.singh-avtcore-mprtp</a>]
+              Singh, V., Karkkainen, T., Ott, J., Ahsan, S., and L.
+              Eggert, "Multipath RTP (MPRTP)", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-singh-avtcore-mprtp-09">draft-singh-avtcore-</a>
+              <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-singh-avtcore-mprtp-09">mprtp-09</a> (work in progress), June 2014.
+
+   [<a name="ref-I-D.williams-peer-redirect" id="ref-I-D.williams-peer-redirect">I-D.williams-peer-redirect</a>]
+              Williams, B. and T. Reddy, "Peer-specific Redirection for
+              Traversal Using Relays around NAT (TURN)", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-williams-peer-redirect-01">draft-williams-</a>
+              <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-williams-peer-redirect-01">peer-redirect-01</a> (work in progress), June 2014.
+
+   [<a name="ref-I-D.wing-mmusic-ice-mobility" id="ref-I-D.wing-mmusic-ice-mobility">I-D.wing-mmusic-ice-mobility</a>]
+              Wing, D., Reddy, T., Patil, P., and P. Martinsen,
+              "Mobility with ICE (MICE)", <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-wing-mmusic-ice-mobility-07">draft-wing-mmusic-ice-</a>
+              <a href="/home/www/tools.ietf.org/tools/rfcmarkup/rfcmarkup?draft=draft-wing-mmusic-ice-mobility-07">mobility-07</a> (work in progress), June 2014.
+
+<span class="h2"><a class="selflink" name="appendix-A" href="#appendix-A">Appendix A</a>.  Change log</span>
+
+   Changes in draft -00:
+
+   o  Initial version, from mailing list discussion post-IETF 90.
+
+Authors' Addresses
+
+   Justin Uberti
+   Google
+   747 6th Ave S
+   Kirkland, WA  98033
+   USA
+
+   Email: justin@uberti.name
+
+
+   Jonathan Lennox
+   Vidyo
+   433 Hackensack Avenue
+   Hackensack, NJ  07601
+   USA
+
+   Email: jonathan@vidyo.com
+
+
+
+
+Uberti &amp; Lennox           Expires May 10, 2015                  [Page 9]
+
+</pre><br />
+<span class="noprint"><small><small>Html markup produced by rfcmarkup 1.109, available from
+<a href="https://tools.ietf.org/tools/rfcmarkup/">https://tools.ietf.org/tools/rfcmarkup/</a>
+</small></small></span>
+</body></html>

--- a/nombis/draft-uberti-mmusic-nombis.txt
+++ b/nombis/draft-uberti-mmusic-nombis.txt
@@ -68,24 +68,24 @@ Table of Contents
      3.3.  Allow Selected Pair Change At Any Time Without Signaling    4
      3.4.  Allow Continuous Addition of Candidates . . . . . . . . .   4
      3.5.  Maintain Backwards Compatibility  . . . . . . . . . . . .   4
-     3.6.  Minimize Complexity Increase  . . . . . . . . . . . . . .   4
+     3.6.  Minimize Complexity Increase  . . . . . . . . . . . . . .   5
    4.  Deprecating Aggressive Nomination . . . . . . . . . . . . . .   5
      4.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   5
      4.2.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   5
      4.3.  Backwards Compatibility . . . . . . . . . . . . . . . . .   6
    5.  Introducing Continuous Nomination . . . . . . . . . . . . . .   6
      5.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   6
-     5.2.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   6
-     5.3.  Backwards Compatibility . . . . . . . . . . . . . . . . .   7
-   6.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .   7
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+     5.2.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   7
+     5.3.  Backwards Compatibility . . . . . . . . . . . . . . . . .   8
+   6.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .   8
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
    9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
    10. References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
      10.1.  Normative References . . . . . . . . . . . . . . . . . .   8
-     10.2.  Informative References . . . . . . . . . . . . . . . . .   8
-   Appendix A.  Change log . . . . . . . . . . . . . . . . . . . . .   8
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   8
+     10.2.  Informative References . . . . . . . . . . . . . . . . .   9
+   Appendix A.  Change log . . . . . . . . . . . . . . . . . . . . .   9
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   9
 
 1.  Introduction
 
@@ -145,23 +145,23 @@ Internet-Draft                   IceNom                    November 2014
    Modern ICE agents will often have multiple network interfaces and
    multiple servers from which to obtain ICE candidates.  While some ICE
    checks may succeed quickly, finishing the entire set of checks can
-   easily take multiple seconds.  As a result, ICE endpoints MUST be
-   able to start transmitting media immediately upon a successful ICE
-   check, and MUST retain the ability to switch if a better candidate
-   pair becomes available later.
+   easily take multiple seconds; this concern is discussed in [RFC5245],
+   Section 8.1.1.1.  As a result, ICE endpoints MUST be able to start
+   transmitting media immediately upon a successful ICE check, and MUST
+   retain the ability to switch if a better candidate pair becomes
+   available later.
 
 3.2.  Allow Controlling Endpoint to Make Dynamic Decisions
 
    While an ICE endpoint will assign various priority values to its ICE
    candidates, these priorities are static and can only be based on a
-   priori knowledge.  To properly make choices in multi-network and
-   multi-server scenarios, the controlling endpoint MUST be able to make
-   dynamic decisions about the selected candidate pair based on observed
-   network performance.  To ensure symmetric flows, this implies that
-   the controlling endpoint MUST be able to communicate its choice to
-   the controlled side.
-
-
+   priori knowledge; the shortcomings of this approach are discussed in
+   the first paragraph of Section 2.6 in [RFC5245].  To properly make
+   choices in multi-network and multi-server scenarios, the controlling
+   endpoint MUST be able to make dynamic decisions about the selected
+   candidate pair based on observed network performance.  For example,
+   RTT could be used to evaluate which TURN servers to use, as described
+   in [I-D.williams-peer-redirect] To ensure symmetric flows, this
 
 
 
@@ -169,6 +169,9 @@ Uberti & Lennox           Expires May 10, 2015                  [Page 3]
 
 Internet-Draft                   IceNom                    November 2014
 
+
+   implies that the controlling endpoint MUST be able to communicate its
+   choice to the controlled side.
 
 3.3.  Allow Selected Pair Change At Any Time Without Signaling
 
@@ -180,26 +183,30 @@ Internet-Draft                   IceNom                    November 2014
    the signaling channel may be affected by the event necessitating the
    switch, this implies that the controlling endpoint MUST be able to
    change the selected pair and indicate this to the remote side without
-   signaling.
+   signaling.  The need for this functionality has been stated in
+   [I-D.wing-mmusic-ice-mobility] and [I-D.singh-avtcore-mprtp].
 
    The rules in [RFC5245] ensure that the controlled endpoint keeps its
    candidate needed for the selected pair alive.  However, in order for
    alternate pairs to remain available, the controlled endpoint must
-   keep the associated candidates alive as well.  This implies that the
-   controlling endpoint MUST have some way to indicate to the controlled
-   side that specific candidates are to be kept alive.
+   keep the associated candidates alive as well, following the
+   procedures outlined in [RFC5245], Section 4.1.1.4.  This implies that
+   the controlling endpoint MUST have some way to indicate to the
+   controlled side that specific candidates are to be kept alive.
 
 3.4.  Allow Continuous Addition of Candidates
 
    In certain network mobility scenarios, networks may come up and down
    while the call is active.  In order to allow candidates gathered on
-   these networks to be used for the selected pair or backup pairs, the
-   endpoint MUST be able to gather candidates on these networks and
-   communicate them to the remote side.  While this could be done using
-   an ICE restart, as described in [RFC5245], the ICE restart implies
-   that these candidates should replace, instead of add to, the
-   previously exchanged candidates.  [TODO: should this just be a tweak
-   to Trickle ICE?  It's not really specific to nomination.]
+   newly available networks to be used for the selected pair or backup
+   pairs, the endpoint MUST be able to gather candidates on these
+   networks and communicate them to the remote side.  While this could
+   be done using an ICE restart, as described in [RFC5245], Section 9.1,
+   the ICE restart may have unintended consequences, such as causing the
+   remote side to regather all candidates.  Instead, it would be best if
+   the new candidates could be trickled, as discussed in
+   [I-D.ietf-mmusic-trickle-ice], but even after ICE processing has
+   completed.
 
 3.5.  Maintain Backwards Compatibility
 
@@ -208,13 +215,6 @@ Internet-Draft                   IceNom                    November 2014
    when interacting with existing endpoints.  However, the ideal
    solution SHOULD allow some improvements to occur when only the
    controlling side supports the new functionality.
-
-3.6.  Minimize Complexity Increase
-
-   Increased functionality typically leads to increased complexity,
-   which leads to more edge cases, and more implementation bugs.  This
-   suggests that in addition to proposing new ICE functionality, the
-   ideal solution SHOULD deprecate superfluous functionality.
 
 
 
@@ -225,6 +225,13 @@ Uberti & Lennox           Expires May 10, 2015                  [Page 4]
 
 Internet-Draft                   IceNom                    November 2014
 
+
+3.6.  Minimize Complexity Increase
+
+   Increased functionality typically leads to increased complexity,
+   which leads to more edge cases, and more implementation bugs.  This
+   suggests that in addition to proposing new ICE functionality, the
+   ideal solution SHOULD deprecate superfluous functionality.
 
 4.  Deprecating Aggressive Nomination
 
@@ -266,13 +273,6 @@ Internet-Draft                   IceNom                    November 2014
    controlling side will finalize this preference through USE-CANDIDATE
    shortly.]
 
-   As this is legal ICE behavior, no negotiation of this mechanism
-   should be needed.  In the event the receiver drops any packets that
-   arrive before a Binding Request with USE-CANDIDATE set, this will
-   simply lead to brief media clipping and will resolve itself once
-   nomination completes.
-
-
 
 
 
@@ -282,22 +282,30 @@ Uberti & Lennox           Expires May 10, 2015                  [Page 5]
 Internet-Draft                   IceNom                    November 2014
 
 
+   As this is legal ICE behavior, no negotiation of this mechanism
+   should be needed.  In the event the receiver drops any packets that
+   arrive before a Binding Request with USE-CANDIDATE set, this will
+   simply lead to brief media clipping and will resolve itself once
+   nomination completes.
+
 4.3.  Backwards Compatibility
 
-   When acting in the controlled role, new implementations MUST not use
+   When acting in the controlled role, new implementations MUST NOT use
    Aggressive Nomination.
 
    When acting in the controlled role, and the controlling side is using
    Aggressive Nomination (e.g. sending USE-CANDIDATE in its initial
    Binding Requests), the standard PRIORITY-based mechanism outlined in
-   [TODO] should be used to determine the reverse media path.
+   [RFC5245], Section 8.1.1.2 should be used to determine the reverse
+   media path.
 
    Note that if implementations would prefer to just avoid Aggressive
    Nomination altogether, they MAY indicate some TBD pseudo-option in
    the ice-options attribute.  Because compliant implementations MUST
    NOT use Aggressive Nomination if an unknown ICE option is
    encountered, this effectively prohibits the use of Aggressive
-   Nomination.
+   Nomination.  [N.B. this could be the ice-options:continuous option
+   described below]
 
 5.  Introducing Continuous Nomination
 
@@ -323,14 +331,6 @@ Internet-Draft                   IceNom                    November 2014
    call setup, the requirements expressed in Section 3.3 and Section 3.4
    can be met.
 
-5.2.  Operation
-
-   Upon receipt of a Binding Request with USE-CANDIDATE, the controlled
-   side MUST switch its media path to the candidate pair on which the
-   Binding Request was received. [could also follow media, if secure]
-
-
-
 
 
 Uberti & Lennox           Expires May 10, 2015                  [Page 6]
@@ -338,39 +338,73 @@ Uberti & Lennox           Expires May 10, 2015                  [Page 6]
 Internet-Draft                   IceNom                    November 2014
 
 
+5.2.  Operation
+
+   Under continuous nomination, ICE never concludes; new candidates can
+   always be trickled, and a new candidate pair can be selected by the
+   controlling side at any time.
+
+   When selecting a new candidate pair, the controlling side informs the
+   controlled side of the chosen pat by sending a new Binding Request
+   with a USE-CANDIDATE attribute.  The decision about which candidate
+   pair to use is fully dynamic; the controlling side can use metrics
+   such as RTT or loss rate to change the selected pair at any time.  If
+   Binding Requests need to be sent for any other reason, such as
+   consent checks [TODO: reference], any checks sent on the selected
+   pair MUST include a USE-CANDIDATE attribute.
+
+   Upon receipt of a Binding Request with USE-CANDIDATE, the controlled
+   side MUST switch its media path to the candidate pair on which the
+   Binding Request was received.
+
    During continuous nomination, the controlling side may still elect to
    prune certain candidate pairs; for example, an implementation may
    choose to drop relay candidates once a successful connection has been
-   established.  The controlling ICE Agent does this by continuing to
-   send Binding Requests to the remote side on each candidate pair that
-   it still wants to retain.  The controlled ICE Agent SHOULD prune any
-   candidate pairs that have not received a Binding Request in N seconds
-   (30?), and SHOULD NOT keep alive any candidates that are not
-   associated with a live candidate pair.  One side benefit of doing
-   this is that the continuous exchange of Binding Requests across all
-   candidate pairs allows the RTT and loss rate for each to be reliably
-   determined and kept up to date.
+   established.  The controlled side, however, should follow the
+   controlling side's lead in terms of deciding whether any pairs should
+   be pruned.  The controlling ICE Agent informs the remote side of its
+   preferences by continuing to send Binding Requests to the remote side
+   on each candidate pair that it wants to retain.  The controlled ICE
+   Agent SHOULD prune any candidate pairs that have not received a
+   Binding Request in N seconds (30?), and SHOULD NOT keep alive any
+   candidates that are not associated with a live candidate pair.
+   [TODO: decide if this implicit timeout approach is correct, or if we
+   should have some sort of approach similar to TURN LIFETIME indicating
+   when a pair should be GCed, with LIFETIME==0 indicating immediate
+   GC.]  One side benefit of doing this is that the continuous exchange
+   of Binding Requests across all candidate pairs allows the RTT and
+   loss rate for each to be reliably determined and kept up to date.
+
+   If the endpoints have negotiated Trickle ICE support [TODO:
+   reference], and new candidates become available on either side, the
+   endpoint may send these candidates to the remote side using the
+   existing Trickle ICE mechanisms.  Once all of the new candidates have
+   been transmitted, the endpoint MUST send an end-of-candidates
+   messages, which indicates that no more candidates will be sent in the
+   near future.
 
    At any point, either side may perform an ICE restart, which will
    result in both sides gathering new ICE candidates, starting a new
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 7]
+
+Internet-Draft                   IceNom                    November 2014
+
+
    continuous nomination sequence, and upon successful completion,
    discarding all candidates from the previous nomination sequence.
 
 5.3.  Backwards Compatibility
-
-   Under continuous nomination, ICE never concludes; new candidates can
-   always be trickled, and a new candidate pair can always be selected
-   by the controlling side by sending a new Binding Request with a USE-
-   CANDIDATE attribute.  The decision about which candidate pair to use
-   is fully dynamic; the controlled side can use metrics such as RTT or
-   loss rate to change the selected pair at any time.
 
    Since standard ICE implementations may not expect the selected pair
    to change after a USE-CANDIDATE attribute is received, support for
    continuous nomination is explicitly indicated via a new "continuous"
    value for ice-options.  If the remote side does not support the
    "continuous" option, the controlling side MUST fall back to Regular
-   Nomination [consistent with the behavior specified in TBD].
+   Nomination, as specified in [RFC5245], Sectiom 8.1.1.
 
 6.  Examples
 
@@ -382,17 +416,8 @@ Internet-Draft                   IceNom                    November 2014
 
 8.  IANA Considerations
 
-   This document requires no actions from IANA.
-
-
-
-
-
-
-Uberti & Lennox           Expires May 10, 2015                  [Page 7]
-
-Internet-Draft                   IceNom                    November 2014
-
+   A new ICE option "continuous" has been [will be] registered in the
+   "ICE Options" registry created by [RFC6336].
 
 9.  Acknowledgements
 
@@ -411,7 +436,27 @@ Internet-Draft                   IceNom                    November 2014
               Traversal for Offer/Answer Protocols", RFC 5245, April
               2010.
 
+   [RFC6336]  Westerlund, M. and C. Perkins, "IANA Registry for
+              Interactive Connectivity Establishment (ICE) Options", RFC
+              6336, July 2011.
+
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 8]
+
+Internet-Draft                   IceNom                    November 2014
+
+
 10.2.  Informative References
+
+   [I-D.ietf-mmusic-trickle-ice]
+              Ivov, E., Rescorla, E., and J. Uberti, "Trickle ICE:
+              Incremental Provisioning of Candidates for the Interactive
+              Connectivity Establishment (ICE) Protocol", draft-ietf-
+              mmusic-trickle-ice-01 (work in progress), February 2014.
 
    [I-D.singh-avtcore-mprtp]
               Singh, V., Karkkainen, T., Ott, J., Ahsan, S., and L.
@@ -436,20 +481,6 @@ Appendix A.  Change log
 
 Authors' Addresses
 
-
-
-
-
-
-
-
-
-
-Uberti & Lennox           Expires May 10, 2015                  [Page 8]
-
-Internet-Draft                   IceNom                    November 2014
-
-
    Justin Uberti
    Google
    747 6th Ave S
@@ -466,37 +497,6 @@ Internet-Draft                   IceNom                    November 2014
    USA
 
    Email: jonathan@vidyo.com
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/nombis/draft-uberti-mmusic-nombis.txt
+++ b/nombis/draft-uberti-mmusic-nombis.txt
@@ -1,0 +1,504 @@
+
+
+
+
+Network Working Group                                          J. Uberti
+Internet-Draft                                                    Google
+Intended status: Standards Track                               J. Lennox
+Expires: May 10, 2015                                              Vidyo
+                                                       November 06, 2014
+
+
+                Improvements to ICE Candidate Nomination
+                     draft-uberti-mmusic-nombis-00
+
+Abstract
+
+   This document makes recommendations for simplifying and improving the
+   procedures for candidate nomination in Interactive Connectivity
+   Establishment (ICE).
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on May 10, 2015.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 1]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Goals and Requirements  . . . . . . . . . . . . . . . . . . .   3
+     3.1.  Minimize Call Setup Latency . . . . . . . . . . . . . . .   3
+     3.2.  Allow Controlling Endpoint to Make Dynamic Decisions  . .   3
+     3.3.  Allow Selected Pair Change At Any Time Without Signaling    4
+     3.4.  Allow Continuous Addition of Candidates . . . . . . . . .   4
+     3.5.  Maintain Backwards Compatibility  . . . . . . . . . . . .   4
+     3.6.  Minimize Complexity Increase  . . . . . . . . . . . . . .   4
+   4.  Deprecating Aggressive Nomination . . . . . . . . . . . . . .   5
+     4.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   5
+     4.2.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   5
+     4.3.  Backwards Compatibility . . . . . . . . . . . . . . . . .   6
+   5.  Introducing Continuous Nomination . . . . . . . . . . . . . .   6
+     5.1.  Overview  . . . . . . . . . . . . . . . . . . . . . . . .   6
+     5.2.  Operation . . . . . . . . . . . . . . . . . . . . . . . .   6
+     5.3.  Backwards Compatibility . . . . . . . . . . . . . . . . .   7
+   6.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . . .   7
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .   8
+     10.2.  Informative References . . . . . . . . . . . . . . . . .   8
+   Appendix A.  Change log . . . . . . . . . . . . . . . . . . . . .   8
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   8
+
+1.  Introduction
+
+   Interactive Connectivity Establishment (ICE) attempts to find the
+   'best' path for connectivity between two peers; in ICE parlance,
+   these paths are known as 'candidate pairs'.  During the ICE process,
+   one endpoint, known as the 'controlling' endpoint, selects a
+   candidate pair as the best pair; this action is known as nomination.
+   ICE supports two different mechanisms for performing nomination,
+   known as Regular Nomination, and Aggressive Nomination.
+
+   However, each of these modes have flaws that restrict their
+   usefulness.  Regular Nomination, as currently speced, requires a best
+   pair to be chosen before media transmission can start, causing
+   unnecessary call setup delay.  Aggressive Nomination, while avoiding
+   this delay, gives the controlling endpoint much less discretion into
+   which candidate pair is chosen, preventing it from making decisions
+   based on dynamic factors such as RTT or loss rate.  Needless to say,
+   the presence of both modes also adds nontrivial complexity.
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 2]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+   Lastly, ICE is currently defined as a finite process, where the
+   decision on the optimal candidate pair is made during call setup and
+   infrequently (if ever) changed.  While this may be acceptable for
+   endpoints with static network configurations, it fails to meet the
+   needs of mobile endpoints, who may need to seamlessly move between
+   networks, or be connected to multiple networks simultaneously.  In
+   these cases, the controlling endpoint may want to maintain multiple
+   potential candidate pairs, and make dynamic decisions to switch
+   between them as conditions change.
+
+   To address these challenges, this document makes two proposals for
+   refactoring ICE nomination - merging Regular and Aggressive
+   Nomination, and introducing a new mode, known as Continuous
+   Nomination.  This makes ICE substantially more flexible without
+   increasing complexity.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+3.  Goals and Requirements
+
+   The goals for improved ICE nomination are enumerated below.
+
+3.1.  Minimize Call Setup Latency
+
+   Modern ICE agents will often have multiple network interfaces and
+   multiple servers from which to obtain ICE candidates.  While some ICE
+   checks may succeed quickly, finishing the entire set of checks can
+   easily take multiple seconds.  As a result, ICE endpoints MUST be
+   able to start transmitting media immediately upon a successful ICE
+   check, and MUST retain the ability to switch if a better candidate
+   pair becomes available later.
+
+3.2.  Allow Controlling Endpoint to Make Dynamic Decisions
+
+   While an ICE endpoint will assign various priority values to its ICE
+   candidates, these priorities are static and can only be based on a
+   priori knowledge.  To properly make choices in multi-network and
+   multi-server scenarios, the controlling endpoint MUST be able to make
+   dynamic decisions about the selected candidate pair based on observed
+   network performance.  To ensure symmetric flows, this implies that
+   the controlling endpoint MUST be able to communicate its choice to
+   the controlled side.
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 3]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+3.3.  Allow Selected Pair Change At Any Time Without Signaling
+
+   Expanding on the requirement above, the need to make dynamic
+   decisions is not limited to call setup.  A multihomed endpoint may
+   need to switch interfaces based on mobility considerations, or a
+   robust endpoint may want to keep multiple network paths warm and
+   switch immediately if connectivity is interrupted on one of them.  As
+   the signaling channel may be affected by the event necessitating the
+   switch, this implies that the controlling endpoint MUST be able to
+   change the selected pair and indicate this to the remote side without
+   signaling.
+
+   The rules in [RFC5245] ensure that the controlled endpoint keeps its
+   candidate needed for the selected pair alive.  However, in order for
+   alternate pairs to remain available, the controlled endpoint must
+   keep the associated candidates alive as well.  This implies that the
+   controlling endpoint MUST have some way to indicate to the controlled
+   side that specific candidates are to be kept alive.
+
+3.4.  Allow Continuous Addition of Candidates
+
+   In certain network mobility scenarios, networks may come up and down
+   while the call is active.  In order to allow candidates gathered on
+   these networks to be used for the selected pair or backup pairs, the
+   endpoint MUST be able to gather candidates on these networks and
+   communicate them to the remote side.  While this could be done using
+   an ICE restart, as described in [RFC5245], the ICE restart implies
+   that these candidates should replace, instead of add to, the
+   previously exchanged candidates.  [TODO: should this just be a tweak
+   to Trickle ICE?  It's not really specific to nomination.]
+
+3.5.  Maintain Backwards Compatibility
+
+   To prevent interoperability problems, ICE endpoints that support the
+   functionality listed above MUST still maintain [RFC5245] compliance
+   when interacting with existing endpoints.  However, the ideal
+   solution SHOULD allow some improvements to occur when only the
+   controlling side supports the new functionality.
+
+3.6.  Minimize Complexity Increase
+
+   Increased functionality typically leads to increased complexity,
+   which leads to more edge cases, and more implementation bugs.  This
+   suggests that in addition to proposing new ICE functionality, the
+   ideal solution SHOULD deprecate superfluous functionality.
+
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 4]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+4.  Deprecating Aggressive Nomination
+
+4.1.  Overview
+
+   The main benefits of Regular Nomination are that the controlling side
+   can dynamically choose which candidate pair to use, and a clear
+   signal when the nomination process has completed, via the presence of
+   the USE-CANDIDATE flag in a Binding Request.  The main benefit of
+   Aggressive Nomination is that it is only necessary to send a single
+   Binding Request before starting the transmission of media, reducing
+   setup latency.  Why don't we have both?
+
+   By preserving the dynamic behavior of Regular Nomination, but
+   allowing media transmission to start upon a single successful
+   connectivity check, as in Aggressive Nomination, the requirements of
+   Section 3.1 and Section 3.2 can be met, while meeting the
+   compatibility requirement from Section 3.5 and, since Aggressive
+   Nomination is no longer needed, the complexity requirement from
+   Section 3.6.
+
+4.2.  Operation
+
+   Since media may be transmitted as soon as all components have a valid
+   pair, as indicated in [RFC5245], Page 69, an ICE Agent can begin
+   transmitting media as soon as this occurs, even if it has not sent a
+   Binding Request with USE-CANDIDATE.
+
+   This pair can change as more pairs are added to the Valid list on the
+   controlling side.  When nomination completes, and a final pair is
+   selected, this is communicated to the controlled side via the typical
+   Binding Request with USE-CANDIDATE.
+
+   On the controlled side, the same process can occur, with the ICE
+   Agent transmitting media as soon as a valid pair exists.  To
+   encourage use of symmetric RTP, the controlled ICE Agent SHOULD use
+   the same candidate pair on which it received media from the
+   controlling side.  [Doesn't need to be secure media, since the
+   controlling side will finalize this preference through USE-CANDIDATE
+   shortly.]
+
+   As this is legal ICE behavior, no negotiation of this mechanism
+   should be needed.  In the event the receiver drops any packets that
+   arrive before a Binding Request with USE-CANDIDATE set, this will
+   simply lead to brief media clipping and will resolve itself once
+   nomination completes.
+
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 5]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+4.3.  Backwards Compatibility
+
+   When acting in the controlled role, new implementations MUST not use
+   Aggressive Nomination.
+
+   When acting in the controlled role, and the controlling side is using
+   Aggressive Nomination (e.g. sending USE-CANDIDATE in its initial
+   Binding Requests), the standard PRIORITY-based mechanism outlined in
+   [TODO] should be used to determine the reverse media path.
+
+   Note that if implementations would prefer to just avoid Aggressive
+   Nomination altogether, they MAY indicate some TBD pseudo-option in
+   the ice-options attribute.  Because compliant implementations MUST
+   NOT use Aggressive Nomination if an unknown ICE option is
+   encountered, this effectively prohibits the use of Aggressive
+   Nomination.
+
+5.  Introducing Continuous Nomination
+
+5.1.  Overview
+
+   As discussed above, in mobile environments there can be multiple
+   possible valid candidate pairs, and these can change at various
+   points in the call, as new interfaces go up and down, signal strength
+   for wireless interfaces changes, and new relay servers are
+   discovered.
+
+   However, under 5245 rules, once a candidate pair is selected and
+   confirmed, via USE-CANDIDATE, nomination has completed and cannot be
+   restarted without performing an ICE restart.  This is overly complex
+   in many cases, and especially problematic in some specific ones,
+   namely a wifi-cellular handover, where the signaling path for
+   communicating an ICE restart may be impacted by the handover.
+
+   To address this situation, this section introduces the concept of
+   "continuous nomination", where the controlling ICE endpoint can
+   adjust the selected candidate pair at any time.  By allowing ICE
+   processing to occur continuously during a call, rather than just at
+   call setup, the requirements expressed in Section 3.3 and Section 3.4
+   can be met.
+
+5.2.  Operation
+
+   Upon receipt of a Binding Request with USE-CANDIDATE, the controlled
+   side MUST switch its media path to the candidate pair on which the
+   Binding Request was received. [could also follow media, if secure]
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 6]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+   During continuous nomination, the controlling side may still elect to
+   prune certain candidate pairs; for example, an implementation may
+   choose to drop relay candidates once a successful connection has been
+   established.  The controlling ICE Agent does this by continuing to
+   send Binding Requests to the remote side on each candidate pair that
+   it still wants to retain.  The controlled ICE Agent SHOULD prune any
+   candidate pairs that have not received a Binding Request in N seconds
+   (30?), and SHOULD NOT keep alive any candidates that are not
+   associated with a live candidate pair.  One side benefit of doing
+   this is that the continuous exchange of Binding Requests across all
+   candidate pairs allows the RTT and loss rate for each to be reliably
+   determined and kept up to date.
+
+   At any point, either side may perform an ICE restart, which will
+   result in both sides gathering new ICE candidates, starting a new
+   continuous nomination sequence, and upon successful completion,
+   discarding all candidates from the previous nomination sequence.
+
+5.3.  Backwards Compatibility
+
+   Under continuous nomination, ICE never concludes; new candidates can
+   always be trickled, and a new candidate pair can always be selected
+   by the controlling side by sending a new Binding Request with a USE-
+   CANDIDATE attribute.  The decision about which candidate pair to use
+   is fully dynamic; the controlled side can use metrics such as RTT or
+   loss rate to change the selected pair at any time.
+
+   Since standard ICE implementations may not expect the selected pair
+   to change after a USE-CANDIDATE attribute is received, support for
+   continuous nomination is explicitly indicated via a new "continuous"
+   value for ice-options.  If the remote side does not support the
+   "continuous" option, the controlling side MUST fall back to Regular
+   Nomination [consistent with the behavior specified in TBD].
+
+6.  Examples
+
+   TODO
+
+7.  Security Considerations
+
+   TODO
+
+8.  IANA Considerations
+
+   This document requires no actions from IANA.
+
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 7]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+9.  Acknowledgements
+
+   Several people provided significant input into this document,
+   including Martin Thomson, Brandon Williams, and Dan Wing.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC5245]  Rosenberg, J., "Interactive Connectivity Establishment
+              (ICE): A Protocol for Network Address Translator (NAT)
+              Traversal for Offer/Answer Protocols", RFC 5245, April
+              2010.
+
+10.2.  Informative References
+
+   [I-D.singh-avtcore-mprtp]
+              Singh, V., Karkkainen, T., Ott, J., Ahsan, S., and L.
+              Eggert, "Multipath RTP (MPRTP)", draft-singh-avtcore-
+              mprtp-09 (work in progress), June 2014.
+
+   [I-D.williams-peer-redirect]
+              Williams, B. and T. Reddy, "Peer-specific Redirection for
+              Traversal Using Relays around NAT (TURN)", draft-williams-
+              peer-redirect-01 (work in progress), June 2014.
+
+   [I-D.wing-mmusic-ice-mobility]
+              Wing, D., Reddy, T., Patil, P., and P. Martinsen,
+              "Mobility with ICE (MICE)", draft-wing-mmusic-ice-
+              mobility-07 (work in progress), June 2014.
+
+Appendix A.  Change log
+
+   Changes in draft -00:
+
+   o  Initial version, from mailing list discussion post-IETF 90.
+
+Authors' Addresses
+
+
+
+
+
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 8]
+
+Internet-Draft                   IceNom                    November 2014
+
+
+   Justin Uberti
+   Google
+   747 6th Ave S
+   Kirkland, WA  98033
+   USA
+
+   Email: justin@uberti.name
+
+
+   Jonathan Lennox
+   Vidyo
+   433 Hackensack Avenue
+   Hackensack, NJ  07601
+   USA
+
+   Email: jonathan@vidyo.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Uberti & Lennox           Expires May 10, 2015                  [Page 9]

--- a/nombis/draft-uberti-mmusic-nombis.xml
+++ b/nombis/draft-uberti-mmusic-nombis.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+<!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
+<!ENTITY rfc5245 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5245.xml">
+<!ENTITY icemob SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.wing-mmusic-ice-mobility.xml">
+<!ENTITY mprtp SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.singh-avtcore-mprtp.xml">
+<!ENTITY redirect SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.williams-peer-redirect.xml">
+]>
+<?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
+<?rfc toc="yes" ?>
+<?rfc symrefs="yes" ?>
+<?rfc iprnotified="no" ?>
+<?rfc strict="yes" ?>
+<?rfc compact="yes" ?>
+<?rfc sortrefs="yes" ?>
+<?rfc colonspace="yes" ?>
+<?rfc rfcedstyle="no" ?>
+<?rfc tocdepth="4"?>
+
+<rfc category="std" docName="draft-uberti-mmusic-nombis-00" ipr="trust200902">
+  <front>
+    <title abbrev="IceNom">Improvements to ICE Candidate Nomination</title>
+
+    <author fullname="Justin Uberti" initials="J." surname="Uberti">
+      <organization>Google</organization>
+
+      <address>
+        <postal>
+          <street>747 6th Ave S</street>
+
+          <city>Kirkland</city>
+
+          <region>WA</region>
+
+          <code>98033</code>
+
+          <country>USA</country>
+        </postal>
+
+        <email>justin@uberti.name</email>
+      </address>
+    </author>
+
+    <author fullname="Jonathan Lennox" initials="J." surname="Lennox">
+      <organization>Vidyo</organization>
+
+      <address>
+        <postal>
+          <street>433 Hackensack Avenue</street>
+
+          <city>Hackensack</city>
+
+          <region>NJ</region>
+
+          <code>07601</code>
+
+          <country>USA</country>
+        </postal>
+
+        <email>jonathan@vidyo.com</email>
+      </address>
+    </author>
+
+    <date day="06" month="November" year="2014" />
+
+    <area>RAI</area>
+
+    <abstract>
+      <t>This document makes recommendations for simplifying and improving the
+      procedures for candidate nomination in Interactive Connectivity Establishment (ICE).</t>
+    </abstract>
+  </front>
+
+  <middle>
+    <section title="Introduction">
+      <t>Interactive Connectivity Establishment (ICE) attempts to find the 'best'
+      path for connectivity between two peers; in ICE parlance, these paths are
+      known as 'candidate pairs'. During the ICE process, one endpoint,
+      known as the 'controlling' endpoint, selects a candidate pair as the 
+      best pair; this action is known as nomination. ICE supports two different
+      mechanisms for performing nomination, known as Regular Nomination, and
+      Aggressive Nomination.</t>
+      <t>However, each of these modes have flaws that restrict their usefulness.
+      Regular Nomination, as currently speced, requires a best pair to be chosen
+      before media transmission can start, causing unnecessary call setup delay.
+      Aggressive Nomination, while avoiding this delay, gives the controlling
+      endpoint much less discretion into which candidate pair is chosen, preventing
+      it from making decisions based on dynamic factors such as RTT or loss rate.
+      Needless to say, the presence of both modes also adds nontrivial complexity.</t>
+      <t>Lastly, ICE is currently defined as a finite process, where the decision on
+      the optimal candidate pair is made during call setup and infrequently (if ever)
+      changed. While this may be acceptable for endpoints with static network 
+      configurations, it fails to meet the needs of mobile endpoints, who may need
+      to seamlessly move between networks, or be connected to multiple networks
+      simultaneously. In these cases, the controlling endpoint may want to maintain
+      multiple potential candidate pairs, and make dynamic decisions to switch 
+      between them as conditions change.</t>
+      <t>To address these challenges, this document makes two proposals for 
+      refactoring ICE nomination - merging Regular and Aggressive Nomination, and 
+      introducing a new mode, known as Continuous Nomination. This makes ICE
+      substantially more flexible without increasing complexity.
+      </t>
+    </section>
+
+    <section title="Terminology">
+      <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+      "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+      document are to be interpreted as described in <xref
+      target="RFC2119"></xref>.</t>
+    </section>
+
+    <section title="Goals and Requirements">
+      <t>The goals for improved ICE nomination are enumerated below.</t>
+      <section title="Minimize Call Setup Latency" anchor="minimize-latency">
+          <t>Modern ICE agents will often have multiple network interfaces and
+          multiple servers from which to obtain ICE candidates. While some ICE checks
+          may succeed quickly, finishing the entire set of checks can easily take multiple
+          seconds. As a result, ICE endpoints MUST be able to start transmitting
+          media immediately upon a successful ICE check, and MUST retain the ability
+          to switch if a better candidate pair becomes available later.
+          </t>
+      </section>
+      <section title="Allow Controlling Endpoint to Make Dynamic Decisions" anchor="dynamic-decisions">
+          <t>While an ICE endpoint will assign various priority values to its ICE candidates,
+          these priorities are static and can only be based on a priori knowledge. To 
+          properly make choices in multi-network and multi-server scenarios, the controlling
+          endpoint MUST be able to make dynamic decisions about the selected candidate pair
+          based on observed network performance. To ensure symmetric flows, this implies that
+          the controlling endpoint MUST be able to communicate its choice to the controlled
+          side.       
+          </t>
+      </section>
+       <section title="Allow Selected Pair Change At Any Time Without Signaling" anchor="continuous-change">
+          <t>Expanding on the requirement above, the need to make dynamic decisions is not
+          limited to call setup. A multihomed endpoint may need to switch interfaces based on
+          mobility considerations, or a robust endpoint may want to keep multiple network paths
+          warm and switch immediately if connectivity is interrupted on one of them. As the
+          signaling channel may be affected by the event necessitating the switch, this
+          implies that the controlling endpoint MUST be able to change the selected pair
+          and indicate this to the remote side without signaling.
+          </t>
+          <t>The rules in <xref target="RFC5245" /> ensure that the controlled
+          endpoint keeps its candidate needed for the selected pair alive. However,
+          in order for alternate pairs to remain available, the controlled endpoint 
+          must keep the associated candidates alive
+          as well. This implies that the controlling endpoint MUST have some way to 
+          indicate to the controlled side that specific candidates are to be kept alive.
+          </t>
+      </section>
+      <section title="Allow Continuous Addition of Candidates" anchor="continuous-candidates">
+          <t>In certain network mobility scenarios, networks may come up and down
+          while the call is active. In order to allow candidates gathered on these 
+          networks to be used for the selected pair or backup pairs, the endpoint MUST
+          be able to gather candidates on these networks and communicate them to the
+          remote side. While this could be done using an ICE restart, as described in
+          <xref target="RFC5245" />, the ICE restart implies that these candidates
+          should replace, instead of add to, the previously exchanged candidates.
+          [TODO: should this just be a tweak to Trickle ICE? It's not really specific
+          to nomination.]         
+          </t>
+      </section>
+      <section title="Maintain Backwards Compatibility" anchor="maintain-backcompat">
+          <t>To prevent interoperability problems, ICE endpoints that support the
+          functionality listed above MUST still maintain <xref target="RFC5245"/> compliance
+          when interacting with existing endpoints. However, the ideal solution SHOULD
+          allow some improvements to occur when only the controlling side supports the new
+          functionality.</t>
+      </section>
+      <section title="Minimize Complexity Increase" anchor="minimize-complexity">
+          <t>Increased functionality typically leads to increased complexity, which
+          leads to more edge cases, and more implementation bugs. This suggests that
+          in addition to proposing new ICE functionality, the ideal solution SHOULD 
+          deprecate superfluous functionality.</t>
+      </section>
+    </section>
+
+    <section title="Deprecating Aggressive Nomination">
+      <section title="Overview">
+        <t>The main benefits of Regular Nomination are that the controlling side can
+         dynamically choose which candidate pair to use, and a clear signal when the
+         nomination process has completed, via the presence of the USE-CANDIDATE flag
+         in a Binding Request. The main benefit of Aggressive Nomination is that it is
+         only necessary to send a single Binding Request before starting the transmission
+         of media, reducing setup latency. Why don't we have both?
+        </t>
+        <t>
+        By preserving the dynamic behavior of Regular Nomination, but allowing media
+        transmission to start upon a single successful connectivity check,
+        as in Aggressive Nomination, the requirements of <xref target="minimize-latency"/>
+        and <xref target="dynamic-decisions"/> can be met, while meeting the compatibility
+        requirement from <xref target="maintain-backcompat" /> and, since
+        Aggressive Nomination is no longer needed, the complexity requirement from 
+        <xref target="minimize-complexity" />.
+        </t>
+      </section>
+      <section title="Operation">
+        <t>Since media may be transmitted as soon as all components have a valid pair,
+        as indicated in <xref target="RFC5245" />, Page 69, an ICE Agent can begin
+        transmitting media as soon as this occurs, even if it has not sent a Binding
+        Request with USE-CANDIDATE.</t>
+        <t>This pair can change as more pairs are added to the Valid list on the controlling side. When
+nomination completes, and a final pair is selected, this is communicated to the controlled side
+via the typical Binding Request with USE-CANDIDATE.</t>
+        <t>On the controlled side, the same process can occur, with the ICE Agent transmitting media as
+soon as a valid pair exists. To encourage use of symmetric RTP, the controlled ICE Agent
+SHOULD use the same candidate pair on which it received media from the controlling side.
+[Doesn't need to be secure media, since the controlling side will finalize this preference
+through USE-CANDIDATE shortly.]</t>
+        <t>As this is legal ICE behavior, no negotiation of this mechanism should be needed. In the
+event the receiver drops any packets that arrive before a Binding Request with
+USE-CANDIDATE set, this will simply lead to brief media clipping and will resolve itself once
+nomination completes.</t>
+      </section>
+      <section title="Backwards Compatibility">
+        <t>When acting in the controlled role, new implementations MUST not use
+        Aggressive Nomination.</t>
+        <t>When acting in the controlled role, and the controlling side is using
+        Aggressive Nomination (e.g. sending USE-CANDIDATE in its initial Binding Requests),
+        the standard PRIORITY-based mechanism outlined in [TODO] should be used to
+        determine the reverse media path.
+        </t>
+        <t>Note that if implementations would prefer to just avoid Aggressive Nomination
+        altogether, they MAY indicate some TBD pseudo-option in the ice-options attribute.
+        Because compliant implementations MUST NOT use Aggressive Nomination if an unknown
+        ICE option is encountered, this effectively prohibits the use of Aggressive Nomination.
+        </t>
+      </section>
+    </section>
+
+    <section title="Introducing Continuous Nomination">
+      <section title="Overview">
+        <t>As discussed above, in mobile environments there can be multiple possible
+        valid candidate pairs, and  these can change at various points in the call, 
+        as new interfaces go up and down, signal strength for wireless interfaces changes,
+        and new relay servers are discovered.</t>
+        <t>However, under 5245 rules, once a candidate pair is selected and confirmed, via
+USE-CANDIDATE, nomination has completed and cannot be restarted without performing an
+ICE restart. This is overly complex in many cases, and especially problematic in some specific
+ones, namely a wifi-cellular handover, where the signaling path for communicating an ICE restart
+may be impacted by the handover.</t>
+        <t>To address this situation, this section introduces the concept of "continuous nomination",
+        where the controlling ICE endpoint can adjust the selected candidate pair at any time.
+        By allowing ICE processing to occur continuously during a call, rather than just at call
+        setup, the requirements expressed in <xref target="continuous-change"/> and
+        <xref target="continuous-candidates"/> can be met.</t>
+      </section>
+      <section title="Operation">
+        
+        <t>Upon receipt of a Binding Request with USE-CANDIDATE, the controlled side MUST switch
+its media path to the candidate pair on which the Binding Request was received. [could also
+follow media, if secure]</t>
+        <t>During continuous nomination, the controlling side may still elect to prune certain candidate
+pairs; for example, an implementation may choose to drop relay candidates once a successful
+connection has been established. The controlling ICE Agent does this by continuing to send
+Binding Requests to the remote side on each candidate pair that it still wants to retain. The
+controlled ICE Agent SHOULD prune any candidate pairs that have not received a Binding
+Request in N seconds (30?), and SHOULD NOT keep alive any candidates that are not
+associated with a live candidate pair. One side benefit of doing this is that the continuous
+exchange of Binding Requests across all candidate pairs allows the RTT and loss rate for
+each to be reliably determined and kept up to date.</t>
+        <t>At any point, either side may perform an ICE restart, which will result in both sides gathering
+new ICE candidates, starting a new continuous nomination sequence, and upon successful
+completion, discarding all candidates from the previous nomination sequence.</t>
+      </section> 
+      <section title="Backwards Compatibility">
+        <t>Under continuous nomination, ICE never concludes; new candidates can always be trickled,
+and a new candidate pair can always be selected by the controlling side by sending a new
+Binding Request with a USE-CANDIDATE attribute. The decision about which candidate pair
+to use is fully dynamic; the controlled side can use metrics such as RTT or loss rate to
+change the selected pair at any time.</t>
+        <t>Since standard ICE implementations may not expect the selected pair to change after a
+USE-CANDIDATE attribute is received, support for continuous nomination is explicitly
+indicated via a new "continuous" value for ice-options. If the remote side does not support the
+"continuous" option, the controlling side MUST fall back to Regular Nomination [consistent
+        with the behavior specified in TBD].</t>
+      </section>
+    </section>
+
+    <section title="Examples">
+      <t>TODO</t>
+    </section>
+
+    <section title="Security Considerations">
+      <t>TODO</t>
+    </section>
+
+    <section title="IANA Considerations">
+      <t>This document requires no actions from IANA.</t>
+    </section>
+
+    <section title="Acknowledgements">
+      <t>Several people provided significant input into this document, including Martin Thomson, Brandon Williams, and Dan Wing.</t>
+    </section>
+  </middle>
+
+  <back>
+    <references title="Normative References">
+      &rfc2119;
+      &rfc5245;
+    </references>
+
+    <references title="Informative References">
+      &redirect;
+      &icemob;
+      &mprtp;
+    </references>
+
+    <section title="Change log">
+      <t>Changes in draft -00: <list style="symbols">
+        <t>Initial version, from mailing list discussion post-IETF 90.</t>
+      </list></t>
+    </section>
+  </back>
+</rfc>

--- a/nombis/draft-uberti-mmusic-nombis.xml
+++ b/nombis/draft-uberti-mmusic-nombis.xml
@@ -2,9 +2,11 @@
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 <!ENTITY rfc2119 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml">
 <!ENTITY rfc5245 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5245.xml">
+<!ENTITY rfc6336 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6336.xml">
 <!ENTITY icemob SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.wing-mmusic-ice-mobility.xml">
 <!ENTITY mprtp SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.singh-avtcore-mprtp.xml">
 <!ENTITY redirect SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.williams-peer-redirect.xml">
+<!ENTITY trickle SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-mmusic-trickle-ice.xml">
 ]>
 <?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?>
 <?rfc toc="yes" ?>
@@ -115,17 +117,22 @@
           <t>Modern ICE agents will often have multiple network interfaces and
           multiple servers from which to obtain ICE candidates. While some ICE checks
           may succeed quickly, finishing the entire set of checks can easily take multiple
-          seconds. As a result, ICE endpoints MUST be able to start transmitting
+          seconds; this concern is discussed in <xref target="RFC5245"/>, Section 8.1.1.1.
+          As a result, ICE endpoints MUST be able to start transmitting
           media immediately upon a successful ICE check, and MUST retain the ability
           to switch if a better candidate pair becomes available later.
           </t>
       </section>
       <section title="Allow Controlling Endpoint to Make Dynamic Decisions" anchor="dynamic-decisions">
           <t>While an ICE endpoint will assign various priority values to its ICE candidates,
-          these priorities are static and can only be based on a priori knowledge. To 
+          these priorities are static and can only be based on a priori knowledge; the 
+          shortcomings of this approach are discussed in the first paragraph of Section 2.6
+          in <xref target="RFC5245"/>. To
           properly make choices in multi-network and multi-server scenarios, the controlling
           endpoint MUST be able to make dynamic decisions about the selected candidate pair
-          based on observed network performance. To ensure symmetric flows, this implies that
+          based on observed network performance. For example, RTT could be used to evaluate
+          which TURN servers to use, as described in <xref target="I-D.williams-peer-redirect"/>
+          To ensure symmetric flows, this implies that
           the controlling endpoint MUST be able to communicate its choice to the controlled
           side.       
           </t>
@@ -137,26 +144,30 @@
           warm and switch immediately if connectivity is interrupted on one of them. As the
           signaling channel may be affected by the event necessitating the switch, this
           implies that the controlling endpoint MUST be able to change the selected pair
-          and indicate this to the remote side without signaling.
+          and indicate this to the remote side without signaling. The need for this 
+          functionality has been stated in <xref target="I-D.wing-mmusic-ice-mobility"/> and
+          <xref target="I-D.singh-avtcore-mprtp"/>.
           </t>
           <t>The rules in <xref target="RFC5245" /> ensure that the controlled
           endpoint keeps its candidate needed for the selected pair alive. However,
           in order for alternate pairs to remain available, the controlled endpoint 
-          must keep the associated candidates alive
-          as well. This implies that the controlling endpoint MUST have some way to 
+          must keep the associated candidates alive as well, following the
+          procedures outlined in <xref target="RFC5245"/>, Section 4.1.1.4. This implies
+          that the controlling endpoint MUST have some way to 
           indicate to the controlled side that specific candidates are to be kept alive.
           </t>
       </section>
       <section title="Allow Continuous Addition of Candidates" anchor="continuous-candidates">
           <t>In certain network mobility scenarios, networks may come up and down
-          while the call is active. In order to allow candidates gathered on these 
-          networks to be used for the selected pair or backup pairs, the endpoint MUST
+          while the call is active. In order to allow candidates gathered on newly
+          available networks to be used for the selected pair or backup pairs, the endpoint MUST
           be able to gather candidates on these networks and communicate them to the
           remote side. While this could be done using an ICE restart, as described in
-          <xref target="RFC5245" />, the ICE restart implies that these candidates
-          should replace, instead of add to, the previously exchanged candidates.
-          [TODO: should this just be a tweak to Trickle ICE? It's not really specific
-          to nomination.]         
+          <xref target="RFC5245" />, Section 9.1, the ICE restart may have unintended
+          consequences, such as causing the remote side to regather all candidates.
+          Instead, it would be best if the new candidates could be trickled, as 
+          discussed in <xref target="I-D.ietf-mmusic-trickle-ice"/>, but even after
+          ICE processing has completed.
           </t>
       </section>
       <section title="Maintain Backwards Compatibility" anchor="maintain-backcompat">
@@ -212,17 +223,18 @@ USE-CANDIDATE set, this will simply lead to brief media clipping and will resolv
 nomination completes.</t>
       </section>
       <section title="Backwards Compatibility">
-        <t>When acting in the controlled role, new implementations MUST not use
+        <t>When acting in the controlled role, new implementations MUST NOT use
         Aggressive Nomination.</t>
         <t>When acting in the controlled role, and the controlling side is using
         Aggressive Nomination (e.g. sending USE-CANDIDATE in its initial Binding Requests),
-        the standard PRIORITY-based mechanism outlined in [TODO] should be used to
-        determine the reverse media path.
+        the standard PRIORITY-based mechanism outlined in <xref target="RFC5245"/>,
+        Section 8.1.1.2 should be used to determine the reverse media path.
         </t>
         <t>Note that if implementations would prefer to just avoid Aggressive Nomination
         altogether, they MAY indicate some TBD pseudo-option in the ice-options attribute.
         Because compliant implementations MUST NOT use Aggressive Nomination if an unknown
         ICE option is encountered, this effectively prohibits the use of Aggressive Nomination.
+        [N.B. this could be the ice-options:continuous option described below]
         </t>
       </section>
     </section>
@@ -245,34 +257,58 @@ may be impacted by the handover.</t>
         <xref target="continuous-candidates"/> can be met.</t>
       </section>
       <section title="Operation">
-        
+        <t>Under continuous nomination, ICE never concludes; new candidates can
+        always be trickled, and a new candidate pair can be selected by the 
+        controlling side at any time.</t>
+        <t>When selecting a new candidate pair, the controlling side informs the
+        controlled side of the chosen pat by sending a new Binding Request
+        with a USE-CANDIDATE attribute.
+        The decision about which candidate pair to use is fully dynamic; the controlling
+        side can use metrics such as RTT or loss rate to change the selected pair at any time.
+        If Binding Requests need to be sent for any other reason, such as consent checks
+        [TODO: reference], any checks sent on the selected pair MUST include a USE-CANDIDATE
+        attribute.
+        </t>
         <t>Upon receipt of a Binding Request with USE-CANDIDATE, the controlled side MUST switch
-its media path to the candidate pair on which the Binding Request was received. [could also
-follow media, if secure]</t>
-        <t>During continuous nomination, the controlling side may still elect to prune certain candidate
-pairs; for example, an implementation may choose to drop relay candidates once a successful
-connection has been established. The controlling ICE Agent does this by continuing to send
-Binding Requests to the remote side on each candidate pair that it still wants to retain. The
-controlled ICE Agent SHOULD prune any candidate pairs that have not received a Binding
-Request in N seconds (30?), and SHOULD NOT keep alive any candidates that are not
-associated with a live candidate pair. One side benefit of doing this is that the continuous
-exchange of Binding Requests across all candidate pairs allows the RTT and loss rate for
-each to be reliably determined and kept up to date.</t>
-        <t>At any point, either side may perform an ICE restart, which will result in both sides gathering
-new ICE candidates, starting a new continuous nomination sequence, and upon successful
-completion, discarding all candidates from the previous nomination sequence.</t>
+        its media path to the candidate pair on which the Binding Request
+        was received.</t>
+        <t>During continuous nomination, the controlling side may still elect
+        to prune certain candidate pairs; for example, an implementation may
+        choose to drop relay candidates once a successful connection has been
+        established. The controlled side, however, should follow the 
+        controlling side's lead in terms of deciding whether any pairs should
+        be pruned. The controlling ICE Agent informs the remote side of its
+        preferences by continuing to send
+        Binding Requests to the remote side on each candidate pair that it
+        wants to retain. The controlled ICE Agent SHOULD prune any
+        candidate pairs that have not received a Binding Request in N seconds
+        (30?), and SHOULD NOT keep alive any candidates that are not
+        associated with a live candidate pair. [TODO: decide if this implicit timeout
+        approach is correct, or if we should have some sort of approach
+        similar to TURN LIFETIME indicating when a pair should be GCed, with
+        LIFETIME==0 indicating immediate GC.] One side benefit of doing this
+        is that the continuous exchange of Binding Requests across all 
+        candidate pairs allows the RTT and loss rate for
+        each to be reliably determined and kept up to date.</t>
+        <t>If the endpoints have negotiated Trickle ICE support
+        [TODO: reference], and new candidates become available on either side,
+        the endpoint may send these candidates to the remote side using
+        the existing Trickle ICE mechanisms. Once all of the new candidates
+        have been transmitted, the endpoint MUST send an end-of-candidates
+        messages, which indicates that no more candidates will be sent
+        in the near future. </t>
+        <t>At any point, either side may perform an ICE restart, which will
+        result in both sides gathering new ICE candidates, starting a new
+        continuous nomination sequence, and upon successful
+        completion, discarding all candidates from the previous nomination
+        sequence.</t>
       </section> 
       <section title="Backwards Compatibility">
-        <t>Under continuous nomination, ICE never concludes; new candidates can always be trickled,
-and a new candidate pair can always be selected by the controlling side by sending a new
-Binding Request with a USE-CANDIDATE attribute. The decision about which candidate pair
-to use is fully dynamic; the controlled side can use metrics such as RTT or loss rate to
-change the selected pair at any time.</t>
         <t>Since standard ICE implementations may not expect the selected pair to change after a
 USE-CANDIDATE attribute is received, support for continuous nomination is explicitly
 indicated via a new "continuous" value for ice-options. If the remote side does not support the
-"continuous" option, the controlling side MUST fall back to Regular Nomination [consistent
-        with the behavior specified in TBD].</t>
+"continuous" option, the controlling side MUST fall back to Regular Nomination, as 
+        specified in <xref target="RFC5245"/>, Sectiom 8.1.1.</t>
       </section>
     </section>
 
@@ -285,11 +321,14 @@ indicated via a new "continuous" value for ice-options. If the remote side does 
     </section>
 
     <section title="IANA Considerations">
-      <t>This document requires no actions from IANA.</t>
+      <t>A new ICE option "continuous" has been [will be] registered
+      in the "ICE Options" registry created by <xref target="RFC6336"/>.  
+      </t>
     </section>
 
     <section title="Acknowledgements">
-      <t>Several people provided significant input into this document, including Martin Thomson, Brandon Williams, and Dan Wing.</t>
+      <t>Several people provided significant input into this document,
+      including Martin Thomson, Brandon Williams, and Dan Wing.</t>
     </section>
   </middle>
 
@@ -297,9 +336,11 @@ indicated via a new "continuous" value for ice-options. If the remote side does 
     <references title="Normative References">
       &rfc2119;
       &rfc5245;
+      &rfc6336;
     </references>
 
     <references title="Informative References">
+      &trickle;
       &redirect;
       &icemob;
       &mprtp;


### PR DESCRIPTION
Suggested changes follow.  Note slight change to current Sec. 5.1.  Would recommend adding new section after current Section 5.1. 

<!ENTITY rfc6363 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6363.xml">
<!ENTITY rfc6681 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6681.xml">

<section title="Recommended Mechanism">
  <t>
    For video content, use of a separate FEC stream with the RTP payload format
    described in <xref target="I-D.singh-payload-rtp-1d2d-parity-scheme"/> is RECOMMENDED.
    The receiver can demultiplex the incoming FEC stream by SSRC and correlate it
    with the primary stream via the ssrc-group mechanism.
  </t>
  <t>
    Note that this only allows the FEC stream to protect a single primary stream (as identified by an SSRC).
    Support for protecting multiple primary streams with a single FEC stream is
    complicated by WebRTC's 1-m-line-per-stream policy and requires further study.
  </t>
</section>

<section title="FEC for Bundled Protection">
  <t>
    <xref target="RFC6363"/> provides for the ability to protect several source flows together.  For instance, it may be desirable under certain conditions to 
    provide bundled protection for multiple video flows along with a single mixed audio flow in a teleconference scenario.  Depending on the FEC scheme chosen,
    the bundled flows may be indicated through the source and repair flow headers described in Section 5 of <xref target="RFC6363"/>.  For instance, <xref target="RFC6681"/>
    does not require a source FEC payload ID but simply leverages the target RTP source stream (that could include multiple CSRC's) along with the associated sequence
    number.  The repair RTP flow, which is assumed to have its own SSRC, uses a repair FEC payload ID constructed as per the procedures outlined in Sections 8.1.3
    and 8.2.4 of <xref target="RFC6681"/>.
  </t>
</section>

<references title="Normative References">
  &rfc2119;
  &rfc2198;
  &rfc5956;
  &rfc6363;
  &fecpayload;
</references>

<references title="Informative References">
  &rfc5109;
  &rfc6716;
  &rfc6681;
  &opuspayload;
</references>