### PR TITLE
Add VP9 profile-id field and profile negotiation

### DIFF
--- a/vp9/draft-ietf-payload-vp9-06.html
+++ b/vp9/draft-ietf-payload-vp9-06.html
@@ -967,9 +967,11 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <dt></dt>
 <dd style="margin-left: 8">The decoder is capable of decoding this frame size as long as the width and height of the frame in macroblocks are less than int(sqrt(max-fs * 8)) - for instance, a max-fs of 1200 (capable of supporting 640x480 resolution) will support widths and heights up to 1552 pixels (97 macroblocks).</dd>
 <dt>profile-id:</dt>
-<dd style="margin-left: 8">The value of profile-id is an integer indicating the default coding profile, the subset of coding tools that may have been used to generate the stream or that the receiver supports). <a href="#TableOfProfiles" class="xref">Table 1</a> lists all of the profiles defined in section 7.2 of <a href="#VP9-BITSTREAM" class="xref">[VP9-BITSTREAM]</a> and the corresponding integer values to be used.</dd>
+<dd style="margin-left: 8">The value of profile-id is an integer indicating the default coding profile, the subset of coding tools that may have been used to generate the stream or that the receiver supports). <a href="#TableOfProfileIds" class="xref">Table 1</a> lists all of the profiles defined in section 7.2 of <a href="#VP9-BITSTREAM" class="xref">[VP9-BITSTREAM]</a> and the corresponding integer values to be used.</dd>
 <dt></dt>
 <dd style="margin-left: 8">If no profile-id is present, Profile 0 MUST be inferred.</dd>
+<dt></dt>
+<dd style="margin-left: 8">Informative note: See <a href="#TableOfProfiles" class="xref">Table 2</a> for capabilities of coding profiles defined in section 7.2 of <a href="#VP9-BITSTREAM" class="xref">[VP9-BITSTREAM]</a>.</dd>
 </dl>
 </dd>
 <dt>Encoding considerations:</dt>
@@ -1004,9 +1006,9 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <br> IETF Payload Working Group delegated from the IESG.</dd>
 </dl>
 <div id="rfc.table.1"></div>
-<div id="TableOfProfiles"></div>
+<div id="TableOfProfileIds"></div>
 <table cellpadding="3" cellspacing="0" class="tt full center">
-<caption>Table 1. Table of profile-id    integer values representing the VP9 profile corresponding to the set of    coding tools supported</caption>
+<caption>Table 1. Table of profile-id    integer values representing the VP9 profile corresponding to the set of    coding tools supported.</caption>
 <thead><tr>
 <th class="center">Profile</th>
 <th class="center">profile-id</th>
@@ -1027,6 +1029,43 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <tr>
 <td class="center">3</td>
 <td class="center">3</td>
+</tr>
+</tbody>
+</table>
+<div id="rfc.table.2"></div>
+<div id="TableOfProfiles"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Table 2. Table of profile    capabilities.</caption>
+<thead><tr>
+<th class="center">Profile</th>
+<th class="center">Bit Depth</th>
+<th class="center">SRGB Colorspace</th>
+<th class="center">Chroma Subsampling</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="center">0</td>
+<td class="center">8</td>
+<td class="center">No</td>
+<td class="center">YUV 4:2:0</td>
+</tr>
+<tr>
+<td class="center">1</td>
+<td class="center">8</td>
+<td class="center">Yes</td>
+<td class="center">YUV 4:2:0,4:4:0 or 4:4:4</td>
+</tr>
+<tr>
+<td class="center">2</td>
+<td class="center">10 or 12</td>
+<td class="center">No</td>
+<td class="center">YUV 4:2:0</td>
+</tr>
+<tr>
+<td class="center">3</td>
+<td class="center">10 or 12</td>
+<td class="center">Yes</td>
+<td class="center">YUV 4:2:0,4:4:0 or 4:4:4</td>
 </tr>
 </tbody>
 </table>

--- a/vp9/draft-ietf-payload-vp9-06.html
+++ b/vp9/draft-ietf-payload-vp9-06.html
@@ -411,7 +411,7 @@
 
   <meta name="dct.creator" content="Uberti, J., Holmer, S., Flodman, M., Lennox, J., and D. Hong" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-payload-vp9-06" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-03" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-10" />
   <meta name="dct.abstract" content="This memo describes an RTP payload format for the VP9 video codec.  The payload format has wide applicability, as it supports applications from low bit-rate peer-to-peer usage, to high bit-rate video conferences.  It includes provisions for temporal and spatial scalability." />
   <meta name="description" content="This memo describes an RTP payload format for the VP9 video codec.  The payload format has wide applicability, as it supports applications from low bit-rate peer-to-peer usage, to high bit-rate video conferences.  It includes provisions for temporal and spatial scalability." />
 
@@ -435,7 +435,7 @@
 <td class="right">M. Flodman</td>
 </tr>
 <tr>
-<td class="left">Expires: January 4, 2019</td>
+<td class="left">Expires: January 11, 2019</td>
 <td class="right">Google</td>
 </tr>
 <tr>
@@ -452,7 +452,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">July 3, 2018</td>
+<td class="right">July 10, 2018</td>
 </tr>
 
     	
@@ -468,7 +468,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on January 4, 2019.</p>
+<p>This Internet-Draft will expire on January 11, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/vp9/draft-ietf-payload-vp9-06.html
+++ b/vp9/draft-ietf-payload-vp9-06.html
@@ -411,7 +411,7 @@
 
   <meta name="dct.creator" content="Uberti, J., Holmer, S., Flodman, M., Lennox, J., and D. Hong" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-payload-vp9-06" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-02" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-03" />
   <meta name="dct.abstract" content="This memo describes an RTP payload format for the VP9 video codec.  The payload format has wide applicability, as it supports applications from low bit-rate peer-to-peer usage, to high bit-rate video conferences.  It includes provisions for temporal and spatial scalability." />
   <meta name="description" content="This memo describes an RTP payload format for the VP9 video codec.  The payload format has wide applicability, as it supports applications from low bit-rate peer-to-peer usage, to high bit-rate video conferences.  It includes provisions for temporal and spatial scalability." />
 
@@ -435,7 +435,7 @@
 <td class="right">M. Flodman</td>
 </tr>
 <tr>
-<td class="left">Expires: January 3, 2019</td>
+<td class="left">Expires: January 4, 2019</td>
 <td class="right">Google</td>
 </tr>
 <tr>
@@ -452,7 +452,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">July 2, 2018</td>
+<td class="right">July 3, 2018</td>
 </tr>
 
     	
@@ -468,7 +468,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on January 3, 2019.</p>
+<p>This Internet-Draft will expire on January 4, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/vp9/draft-ietf-payload-vp9-06.html
+++ b/vp9/draft-ietf-payload-vp9-06.html
@@ -1011,15 +1011,21 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <li>The media name in the "m=" line of SDP MUST be video.</li>
 <li>The encoding name in the "a=rtpmap" line of SDP MUST be VP9 (the media subtype).</li>
 <li>The clock rate in the "a=rtpmap" line MUST be 90000.</li>
-<li>The parameters "max-fs", and "max-fr", MUST be included in the "a=fmtp" line of SDP if SDP is used to declare receiver capabilities.  These parameters are expressed as a media subtype string, in the form of a semicolon separated list of parameter=value pairs.</li>
+<li>The parameters "max-fs", and "max-fr", MUST be included in the "a=fmtp" line of SDP if SDP is used to declare receiver capabilities. These parameters are expressed as a media subtype string, in the form of a semicolon separated list of parameter=value pairs.</li>
+<li>The OPTIONAL parameter profile-id, when present, MUST be included in the "a=fmtp" line of SDP. This parameter is expressed as a media subtype string, in the form of a parameter=value pair.</li>
 </ul>
 <h1 id="rfc.section.6.2.1.1">
 <a href="#rfc.section.6.2.1.1">6.2.1.1.</a> Example</h1>
 <p id="rfc.section.6.2.1.1.p.1">An example of media representation in SDP is as follows:</p>
-<p id="rfc.section.6.2.1.1.p.2">m=video 49170 RTP/AVPF 98<br> a=rtpmap:98 VP9/90000<br> a=fmtp:98 max-fr=30; max-fs=3600;<br></p>
+<p id="rfc.section.6.2.1.1.p.2">m=video 49170 RTP/AVPF 98<br> a=rtpmap:98 VP9/90000<br> a=fmtp:98 max-fr=30; max-fs=3600; profile-id=0;<br></p>
 <h1 id="rfc.section.6.2.2">
 <a href="#rfc.section.6.2.2">6.2.2.</a> Offer/Answer Considerations</h1>
-<p id="rfc.section.6.2.2.p.1">TODO: Update this for VP9</p>
+<p id="rfc.section.6.2.2.p.1">When VP9 is offered over RTP using SDP in an Offer/Answer model <a href="#RFC3264" class="xref">[RFC3264]</a> for negotiation for unicast usage, the following limitations and rules apply: </p>
+
+<ul>
+<li>The parameter identifying a media format configuration for VP9 is profile-id. This media format configuration parameter MUST be used symmetrically; that is, the answerer MUST either maintain all configuration parameters or remove the media format (payload type) completely if one or more of the parameter values are not supported.</li>
+<li>To simplify the handling and matching of these configurations, the same RTP payload type number used in the offer SHOULD also be used in the answer, as specified in <a href="#RFC3264" class="xref">[RFC3264]</a>.  An answer MUST NOT contain the payload type number used in the offer unless the configuration is exactly the same as in the offer.</li>
+</ul>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> <a href="#securityConsiderations" id="securityConsiderations">Security Considerations</a>
 </h1>
@@ -1052,6 +1058,11 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
 <a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+</tr>
+<tr>
+<td class="reference"><b id="RFC3264">[RFC3264]</b></td>
+<td class="top">
+<a>Rosenberg, J.</a> and <a>H. Schulzrinne</a>, "<a href="https://tools.ietf.org/html/rfc3264">An Offer/Answer Model with Session Description Protocol (SDP)</a>", RFC 3264, DOI 10.17487/RFC3264, June 2002.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC3550">[RFC3550]</b></td>

--- a/vp9/draft-ietf-payload-vp9-06.html
+++ b/vp9/draft-ietf-payload-vp9-06.html
@@ -966,6 +966,10 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <dd style="margin-left: 8">The value of max-fs is an integer indicating the maximum frame size in units of macroblocks that the decoder is capable of decoding.</dd>
 <dt></dt>
 <dd style="margin-left: 8">The decoder is capable of decoding this frame size as long as the width and height of the frame in macroblocks are less than int(sqrt(max-fs * 8)) - for instance, a max-fs of 1200 (capable of supporting 640x480 resolution) will support widths and heights up to 1552 pixels (97 macroblocks).</dd>
+<dt>profile-id:</dt>
+<dd style="margin-left: 8">The value of profile-id is an integer indicating the default coding profile, the subset of coding tools that may have been used to generate the stream or that the receiver supports). <a href="#TableOfProfiles" class="xref">Table 1</a> lists all of the profiles defined in section 7.2 of <a href="#VP9-BITSTREAM" class="xref">[VP9-BITSTREAM]</a> and the corresponding integer values to be used.</dd>
+<dt></dt>
+<dd style="margin-left: 8">If no profile-id is present, Profile 0 MUST be inferred.</dd>
 </dl>
 </dd>
 <dt>Encoding considerations:</dt>
@@ -999,6 +1003,33 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <dd style="margin-left: 8">
 <br> IETF Payload Working Group delegated from the IESG.</dd>
 </dl>
+<div id="rfc.table.1"></div>
+<div id="TableOfProfiles"></div>
+<table cellpadding="3" cellspacing="0" class="tt full center">
+<caption>Table 1. Table of profile-id    integer values representing the VP9 profile corresponding to the set of    coding tools supported</caption>
+<thead><tr>
+<th class="center">Profile</th>
+<th class="center">profile-id</th>
+</tr></thead>
+<tbody>
+<tr>
+<td class="center">0</td>
+<td class="center">0</td>
+</tr>
+<tr>
+<td class="center">1</td>
+<td class="center">1</td>
+</tr>
+<tr>
+<td class="center">2</td>
+<td class="center">2</td>
+</tr>
+<tr>
+<td class="center">3</td>
+<td class="center">3</td>
+</tr>
+</tbody>
+</table>
 <h1 id="rfc.section.6.2">
 <a href="#rfc.section.6.2">6.2.</a> <a href="#SDPParameters" id="SDPParameters">SDP Parameters</a>
 </h1>
@@ -1012,7 +1043,7 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 <li>The encoding name in the "a=rtpmap" line of SDP MUST be VP9 (the media subtype).</li>
 <li>The clock rate in the "a=rtpmap" line MUST be 90000.</li>
 <li>The parameters "max-fs", and "max-fr", MUST be included in the "a=fmtp" line of SDP if SDP is used to declare receiver capabilities. These parameters are expressed as a media subtype string, in the form of a semicolon separated list of parameter=value pairs.</li>
-<li>The OPTIONAL parameter profile-id, when present, MUST be included in the "a=fmtp" line of SDP. This parameter is expressed as a media subtype string, in the form of a parameter=value pair.</li>
+<li>The OPTIONAL parameter profile-id, when present, SHOULD be included in the "a=fmtp" line of SDP. This parameter is expressed as a media subtype string, in the form of a parameter=value pair. When the parameter is not present, a value of 0 MUST be used for profile-id.</li>
 </ul>
 <h1 id="rfc.section.6.2.1.1">
 <a href="#rfc.section.6.2.1.1">6.2.1.1.</a> Example</h1>
@@ -1024,7 +1055,7 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 
 <ul>
 <li>The parameter identifying a media format configuration for VP9 is profile-id. This media format configuration parameter MUST be used symmetrically; that is, the answerer MUST either maintain all configuration parameters or remove the media format (payload type) completely if one or more of the parameter values are not supported.</li>
-<li>To simplify the handling and matching of these configurations, the same RTP payload type number used in the offer SHOULD also be used in the answer, as specified in <a href="#RFC3264" class="xref">[RFC3264]</a>.  An answer MUST NOT contain the payload type number used in the offer unless the configuration is exactly the same as in the offer.</li>
+<li>To simplify the handling and matching of these configurations, the same RTP payload type number used in the offer SHOULD also be used in the answer, as specified in <a href="#RFC3264" class="xref">[RFC3264]</a>. An answer MUST NOT contain the payload type number used in the offer unless the configuration is exactly the same as in the offer.</li>
 </ul>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> <a href="#securityConsiderations" id="securityConsiderations">Security Considerations</a>

--- a/vp9/draft-ietf-payload-vp9-06.html
+++ b/vp9/draft-ietf-payload-vp9-06.html
@@ -411,7 +411,7 @@
 
   <meta name="dct.creator" content="Uberti, J., Holmer, S., Flodman, M., Lennox, J., and D. Hong" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-payload-vp9-06" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-10" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-11" />
   <meta name="dct.abstract" content="This memo describes an RTP payload format for the VP9 video codec.  The payload format has wide applicability, as it supports applications from low bit-rate peer-to-peer usage, to high bit-rate video conferences.  It includes provisions for temporal and spatial scalability." />
   <meta name="description" content="This memo describes an RTP payload format for the VP9 video codec.  The payload format has wide applicability, as it supports applications from low bit-rate peer-to-peer usage, to high bit-rate video conferences.  It includes provisions for temporal and spatial scalability." />
 
@@ -435,7 +435,7 @@
 <td class="right">M. Flodman</td>
 </tr>
 <tr>
-<td class="left">Expires: January 11, 2019</td>
+<td class="left">Expires: January 12, 2019</td>
 <td class="right">Google</td>
 </tr>
 <tr>
@@ -452,7 +452,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">July 10, 2018</td>
+<td class="right">July 11, 2018</td>
 </tr>
 
     	
@@ -468,7 +468,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on January 11, 2019.</p>
+<p>This Internet-Draft will expire on January 12, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/vp9/draft-ietf-payload-vp9-06.txt
+++ b/vp9/draft-ietf-payload-vp9-06.txt
@@ -5,11 +5,11 @@
 Payload Working Group                                          J. Uberti
 Internet-Draft                                                 S. Holmer
 Intended status: Standards Track                              M. Flodman
-Expires: January 3, 2019                                          Google
+Expires: January 4, 2019                                          Google
                                                                J. Lennox
                                                                  D. Hong
                                                                    Vidyo
-                                                            July 2, 2018
+                                                            July 3, 2018
 
 
                     RTP Payload Format for VP9 Video
@@ -38,7 +38,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 3, 2019.
+   This Internet-Draft will expire on January 4, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 1]
+Uberti, et al.           Expires January 4, 2019                [Page 1]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 2]
+Uberti, et al.           Expires January 4, 2019                [Page 2]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -165,7 +165,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 3]
+Uberti, et al.           Expires January 4, 2019                [Page 3]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -221,7 +221,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 4]
+Uberti, et al.           Expires January 4, 2019                [Page 4]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -277,7 +277,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 5]
+Uberti, et al.           Expires January 4, 2019                [Page 5]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -333,7 +333,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 6]
+Uberti, et al.           Expires January 4, 2019                [Page 6]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -389,7 +389,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 7]
+Uberti, et al.           Expires January 4, 2019                [Page 7]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -445,7 +445,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 8]
+Uberti, et al.           Expires January 4, 2019                [Page 8]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -501,7 +501,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019                [Page 9]
+Uberti, et al.           Expires January 4, 2019                [Page 9]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -557,7 +557,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 10]
+Uberti, et al.           Expires January 4, 2019               [Page 10]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -613,7 +613,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 11]
+Uberti, et al.           Expires January 4, 2019               [Page 11]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -669,7 +669,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 12]
+Uberti, et al.           Expires January 4, 2019               [Page 12]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -725,7 +725,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 13]
+Uberti, et al.           Expires January 4, 2019               [Page 13]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -781,7 +781,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 14]
+Uberti, et al.           Expires January 4, 2019               [Page 14]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -837,7 +837,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 15]
+Uberti, et al.           Expires January 4, 2019               [Page 15]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -893,7 +893,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 16]
+Uberti, et al.           Expires January 4, 2019               [Page 16]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -949,7 +949,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 17]
+Uberti, et al.           Expires January 4, 2019               [Page 17]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1005,7 +1005,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 18]
+Uberti, et al.           Expires January 4, 2019               [Page 18]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1061,7 +1061,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 19]
+Uberti, et al.           Expires January 4, 2019               [Page 19]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1117,7 +1117,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 20]
+Uberti, et al.           Expires January 4, 2019               [Page 20]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1173,7 +1173,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 21]
+Uberti, et al.           Expires January 4, 2019               [Page 21]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1229,7 +1229,7 @@ Authors' Addresses
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 22]
+Uberti, et al.           Expires January 4, 2019               [Page 22]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1285,4 +1285,4 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 3, 2019               [Page 23]
+Uberti, et al.           Expires January 4, 2019               [Page 23]

--- a/vp9/draft-ietf-payload-vp9-06.txt
+++ b/vp9/draft-ietf-payload-vp9-06.txt
@@ -5,11 +5,11 @@
 Payload Working Group                                          J. Uberti
 Internet-Draft                                                 S. Holmer
 Intended status: Standards Track                              M. Flodman
-Expires: January 11, 2019                                         Google
+Expires: January 12, 2019                                         Google
                                                                J. Lennox
                                                                  D. Hong
                                                                    Vidyo
-                                                           July 10, 2018
+                                                           July 11, 2018
 
 
                     RTP Payload Format for VP9 Video
@@ -38,7 +38,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 11, 2019.
+   This Internet-Draft will expire on January 12, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 1]
+Uberti, et al.          Expires January 12, 2019                [Page 1]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 2]
+Uberti, et al.          Expires January 12, 2019                [Page 2]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -165,7 +165,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 3]
+Uberti, et al.          Expires January 12, 2019                [Page 3]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -221,7 +221,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 4]
+Uberti, et al.          Expires January 12, 2019                [Page 4]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -277,7 +277,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 5]
+Uberti, et al.          Expires January 12, 2019                [Page 5]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -333,7 +333,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 6]
+Uberti, et al.          Expires January 12, 2019                [Page 6]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -389,7 +389,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 7]
+Uberti, et al.          Expires January 12, 2019                [Page 7]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -445,7 +445,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 8]
+Uberti, et al.          Expires January 12, 2019                [Page 8]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -501,7 +501,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019                [Page 9]
+Uberti, et al.          Expires January 12, 2019                [Page 9]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -557,7 +557,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 10]
+Uberti, et al.          Expires January 12, 2019               [Page 10]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -613,7 +613,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 11]
+Uberti, et al.          Expires January 12, 2019               [Page 11]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -669,7 +669,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 12]
+Uberti, et al.          Expires January 12, 2019               [Page 12]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -725,7 +725,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 13]
+Uberti, et al.          Expires January 12, 2019               [Page 13]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -781,7 +781,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 14]
+Uberti, et al.          Expires January 12, 2019               [Page 14]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -837,7 +837,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 15]
+Uberti, et al.          Expires January 12, 2019               [Page 15]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -893,7 +893,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 16]
+Uberti, et al.          Expires January 12, 2019               [Page 16]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -949,7 +949,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 17]
+Uberti, et al.          Expires January 12, 2019               [Page 17]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1005,7 +1005,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 18]
+Uberti, et al.          Expires January 12, 2019               [Page 18]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1061,7 +1061,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 19]
+Uberti, et al.          Expires January 12, 2019               [Page 19]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1117,7 +1117,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 20]
+Uberti, et al.          Expires January 12, 2019               [Page 20]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1173,7 +1173,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 21]
+Uberti, et al.          Expires January 12, 2019               [Page 21]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1229,7 +1229,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 22]
+Uberti, et al.          Expires January 12, 2019               [Page 22]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1285,7 +1285,7 @@ Authors' Addresses
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 23]
+Uberti, et al.          Expires January 12, 2019               [Page 23]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1341,4 +1341,4 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 11, 2019               [Page 24]
+Uberti, et al.          Expires January 12, 2019               [Page 24]

--- a/vp9/draft-ietf-payload-vp9-06.txt
+++ b/vp9/draft-ietf-payload-vp9-06.txt
@@ -5,11 +5,11 @@
 Payload Working Group                                          J. Uberti
 Internet-Draft                                                 S. Holmer
 Intended status: Standards Track                              M. Flodman
-Expires: January 4, 2019                                          Google
+Expires: January 11, 2019                                         Google
                                                                J. Lennox
                                                                  D. Hong
                                                                    Vidyo
-                                                            July 3, 2018
+                                                           July 10, 2018
 
 
                     RTP Payload Format for VP9 Video
@@ -38,7 +38,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 4, 2019.
+   This Internet-Draft will expire on January 11, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 1]
+Uberti, et al.          Expires January 11, 2019                [Page 1]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 2]
+Uberti, et al.          Expires January 11, 2019                [Page 2]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -165,7 +165,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 3]
+Uberti, et al.          Expires January 11, 2019                [Page 3]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -221,7 +221,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 4]
+Uberti, et al.          Expires January 11, 2019                [Page 4]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -277,7 +277,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 5]
+Uberti, et al.          Expires January 11, 2019                [Page 5]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -333,7 +333,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 6]
+Uberti, et al.          Expires January 11, 2019                [Page 6]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -389,7 +389,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 7]
+Uberti, et al.          Expires January 11, 2019                [Page 7]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -445,7 +445,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 8]
+Uberti, et al.          Expires January 11, 2019                [Page 8]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -501,7 +501,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019                [Page 9]
+Uberti, et al.          Expires January 11, 2019                [Page 9]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -557,7 +557,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 10]
+Uberti, et al.          Expires January 11, 2019               [Page 10]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -613,7 +613,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 11]
+Uberti, et al.          Expires January 11, 2019               [Page 11]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -669,7 +669,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 12]
+Uberti, et al.          Expires January 11, 2019               [Page 12]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -725,7 +725,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 13]
+Uberti, et al.          Expires January 11, 2019               [Page 13]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -781,7 +781,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 14]
+Uberti, et al.          Expires January 11, 2019               [Page 14]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -837,7 +837,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 15]
+Uberti, et al.          Expires January 11, 2019               [Page 15]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -893,7 +893,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 16]
+Uberti, et al.          Expires January 11, 2019               [Page 16]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -949,7 +949,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 17]
+Uberti, et al.          Expires January 11, 2019               [Page 17]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1005,7 +1005,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 18]
+Uberti, et al.          Expires January 11, 2019               [Page 18]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1061,7 +1061,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 19]
+Uberti, et al.          Expires January 11, 2019               [Page 19]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1117,7 +1117,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 20]
+Uberti, et al.          Expires January 11, 2019               [Page 20]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1173,7 +1173,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 21]
+Uberti, et al.          Expires January 11, 2019               [Page 21]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1229,7 +1229,7 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 22]
+Uberti, et al.          Expires January 11, 2019               [Page 22]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1285,7 +1285,7 @@ Authors' Addresses
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 23]
+Uberti, et al.          Expires January 11, 2019               [Page 23]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
@@ -1341,4 +1341,4 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 24]
+Uberti, et al.          Expires January 11, 2019               [Page 24]

--- a/vp9/draft-ietf-payload-vp9-06.txt
+++ b/vp9/draft-ietf-payload-vp9-06.txt
@@ -86,14 +86,14 @@ Table of Contents
    6.  Payload Format Parameters . . . . . . . . . . . . . . . . . .  17
      6.1.  Media Type Definition . . . . . . . . . . . . . . . . . .  18
      6.2.  SDP Parameters  . . . . . . . . . . . . . . . . . . . . .  19
-       6.2.1.  Mapping of Media Subtype Parameters to SDP  . . . . .  19
+       6.2.1.  Mapping of Media Subtype Parameters to SDP  . . . . .  20
        6.2.2.  Offer/Answer Considerations . . . . . . . . . . . . .  20
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  21
    8.  Congestion Control  . . . . . . . . . . . . . . . . . . . . .  21
    9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  21
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  21
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  21
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  22
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  22
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  22
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  23
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
@@ -985,6 +985,15 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
          of supporting 640x480 resolution) will support widths and
          heights up to 1552 pixels (97 macroblocks).
 
+      profile-id:  The value of profile-id is an integer indicating the
+         default coding profile, the subset of coding tools that may
+         have been used to generate the stream or that the receiver
+         supports).  Table 1 lists all of the profiles defined in
+         section 7.2 of [VP9-BITSTREAM] and the corresponding integer
+         values to be used.
+
+         If no profile-id is present, Profile 0 MUST be inferred.
+
    Encoding considerations:
       This media type is framed in RTP and contains binary data; see
       Section 4.8 of [RFC6838].
@@ -992,6 +1001,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    Security considerations:  See Section 7 of RFC xxxx.
       [RFC Editor: Upon publication as an RFC, please replace "XXXX"
       with the number assigned to this document and remove this note.]
+
+
+
+
+Uberti, et al.          Expires January 11, 2019               [Page 18]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
 
    Interoperability considerations:  None.
 
@@ -1002,13 +1019,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
    Applications which use this media type:
       For example: Video over IP, video conferencing.
-
-
-
-Uberti, et al.          Expires January 11, 2019               [Page 18]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
 
    Fragment identifier considerations:  N/A.
 
@@ -1028,9 +1038,33 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    Change controller:
       IETF Payload Working Group delegated from the IESG.
 
+                         +---------+------------+
+                         | Profile | profile-id |
+                         +---------+------------+
+                         |    0    |     0      |
+                         |         |            |
+                         |    1    |     1      |
+                         |         |            |
+                         |    2    |     2      |
+                         |         |            |
+                         |    3    |     3      |
+                         +---------+------------+
+
+    Table 1: Table 1.  Table of profile-id integer values representing
+    the VP9 profile corresponding to the set of coding tools supported
+
 6.2.  SDP Parameters
 
    The receiver MUST ignore any fmtp parameter unspecified in this memo.
+
+
+
+
+
+Uberti, et al.          Expires January 11, 2019               [Page 19]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
 
 6.2.1.  Mapping of Media Subtype Parameters to SDP
 
@@ -1050,21 +1084,11 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
       string, in the form of a semicolon separated list of
       parameter=value pairs.
 
-   o  The OPTIONAL parameter profile-id, when present, MUST be included
-      in the "a=fmtp" line of SDP.  This parameter is expressed as a
-      media subtype string, in the form of a parameter=value pair.
-
-
-
-
-
-
-
-
-Uberti, et al.          Expires January 11, 2019               [Page 19]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
+   o  The OPTIONAL parameter profile-id, when present, SHOULD be
+      included in the "a=fmtp" line of SDP.  This parameter is expressed
+      as a media subtype string, in the form of a parameter=value pair.
+      When the parameter is not present, a value of 0 MUST be used for
+      profile-id.
 
 6.2.1.1.  Example
 
@@ -1090,6 +1114,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    o  To simplify the handling and matching of these configurations, the
       same RTP payload type number used in the offer SHOULD also be used
       in the answer, as specified in [RFC3264].  An answer MUST NOT
+
+
+
+Uberti, et al.          Expires January 11, 2019               [Page 20]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
       contain the payload type number used in the offer unless the
       configuration is exactly the same as in the offer.
 
@@ -1114,14 +1146,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
    This RTP payload format and its media decoder do not exhibit any
    significant non-uniformity in the receiver-side computational
-
-
-
-Uberti, et al.          Expires January 11, 2019               [Page 20]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
-
    complexity for packet processing, and thus are unlikely to pose a
    denial-of-service threat due to the receipt of pathological data.
    Nor does the RTP payload format contain any active content.
@@ -1143,6 +1167,16 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
    The IANA is requested to register the following values:
    - Media type registration as described in Section 6.1.
+
+
+
+
+
+
+Uberti, et al.          Expires January 11, 2019               [Page 21]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
 
 10.  References
 
@@ -1169,15 +1203,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               DOI 10.17487/RFC3264, June 2002,
               <https://www.rfc-editor.org/info/rfc3264>.
 
-
-
-
-
-Uberti, et al.          Expires January 11, 2019               [Page 21]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
-
    [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
               Jacobson, "RTP: A Transport Protocol for Real-Time
               Applications", STD 64, RFC 3550, DOI 10.17487/RFC3550,
@@ -1202,6 +1227,13 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               with Feedback (AVPF)", RFC 5104, DOI 10.17487/RFC5104,
               February 2008, <https://www.rfc-editor.org/info/rfc5104>.
 
+
+
+Uberti, et al.          Expires January 11, 2019               [Page 22]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    [RFC6838]  Freed, N., Klensin, J., and T. Hansen, "Media Type
               Specifications and Registration Procedures", BCP 13,
               RFC 6838, DOI 10.17487/RFC6838, January 2013,
@@ -1225,14 +1257,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               Norrman, "The Secure Real-time Transport Protocol (SRTP)",
               RFC 3711, DOI 10.17487/RFC3711, March 2004,
               <https://www.rfc-editor.org/info/rfc3711>.
-
-
-
-
-Uberti, et al.          Expires January 11, 2019               [Page 22]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
 
    [RFC5124]  Ott, J. and E. Carrara, "Extended Secure RTP Profile for
               Real-time Transport Control Protocol (RTCP)-Based Feedback
@@ -1259,6 +1283,13 @@ Authors' Addresses
    Email: justin@uberti.name
 
 
+
+
+Uberti, et al.          Expires January 11, 2019               [Page 23]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    Stefan Holmer
    Google, Inc.
    Kungsbron 2
@@ -1275,19 +1306,6 @@ Authors' Addresses
    Sweden
 
    Email: mflodman@google.com
-
-
-
-
-
-
-
-
-
-
-Uberti, et al.          Expires January 11, 2019               [Page 23]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
    Jonathan Lennox
@@ -1308,24 +1326,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    US
 
    Email: danny@vidyo.com
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/vp9/draft-ietf-payload-vp9-06.txt
+++ b/vp9/draft-ietf-payload-vp9-06.txt
@@ -85,16 +85,16 @@ Table of Contents
      5.5.  Frame Marking . . . . . . . . . . . . . . . . . . . . . .  17
    6.  Payload Format Parameters . . . . . . . . . . . . . . . . . .  17
      6.1.  Media Type Definition . . . . . . . . . . . . . . . . . .  18
-     6.2.  SDP Parameters  . . . . . . . . . . . . . . . . . . . . .  19
+     6.2.  SDP Parameters  . . . . . . . . . . . . . . . . . . . . .  20
        6.2.1.  Mapping of Media Subtype Parameters to SDP  . . . . .  20
-       6.2.2.  Offer/Answer Considerations . . . . . . . . . . . . .  20
+       6.2.2.  Offer/Answer Considerations . . . . . . . . . . . . .  21
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  21
-   8.  Congestion Control  . . . . . . . . . . . . . . . . . . . . .  21
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  21
+   8.  Congestion Control  . . . . . . . . . . . . . . . . . . . . .  22
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  22
    10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  22
      10.1.  Normative References . . . . . . . . . . . . . . . . . .  22
      10.2.  Informative References . . . . . . . . . . . . . . . . .  23
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  24
 
 1.  Introduction
 
@@ -994,14 +994,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
          If no profile-id is present, Profile 0 MUST be inferred.
 
+         Informative note: See Table 2 for capabilities of coding
+         profiles defined in section 7.2 of [VP9-BITSTREAM].
+
    Encoding considerations:
       This media type is framed in RTP and contains binary data; see
       Section 4.8 of [RFC6838].
 
    Security considerations:  See Section 7 of RFC xxxx.
-      [RFC Editor: Upon publication as an RFC, please replace "XXXX"
-      with the number assigned to this document and remove this note.]
-
 
 
 
@@ -1009,6 +1009,9 @@ Uberti, et al.          Expires January 12, 2019               [Page 18]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
+
+      [RFC Editor: Upon publication as an RFC, please replace "XXXX"
+      with the number assigned to this document and remove this note.]
 
    Interoperability considerations:  None.
 
@@ -1051,11 +1054,8 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
                          +---------+------------+
 
     Table 1: Table 1.  Table of profile-id integer values representing
-    the VP9 profile corresponding to the set of coding tools supported
+    the VP9 profile corresponding to the set of coding tools supported.
 
-6.2.  SDP Parameters
-
-   The receiver MUST ignore any fmtp parameter unspecified in this memo.
 
 
 
@@ -1065,6 +1065,24 @@ Uberti, et al.          Expires January 12, 2019               [Page 19]
 
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
+
+   +---------+-----------+-----------------+--------------------------+
+   | Profile | Bit Depth | SRGB Colorspace |    Chroma Subsampling    |
+   +---------+-----------+-----------------+--------------------------+
+   |    0    |     8     |        No       |        YUV 4:2:0         |
+   |         |           |                 |                          |
+   |    1    |     8     |       Yes       | YUV 4:2:0,4:4:0 or 4:4:4 |
+   |         |           |                 |                          |
+   |    2    |  10 or 12 |        No       |        YUV 4:2:0         |
+   |         |           |                 |                          |
+   |    3    |  10 or 12 |       Yes       | YUV 4:2:0,4:4:0 or 4:4:4 |
+   +---------+-----------+-----------------+--------------------------+
+
+             Table 2: Table 2.  Table of profile capabilities.
+
+6.2.  SDP Parameters
+
+   The receiver MUST ignore any fmtp parameter unspecified in this memo.
 
 6.2.1.  Mapping of Media Subtype Parameters to SDP
 
@@ -1096,6 +1114,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
    m=video 49170 RTP/AVPF 98
    a=rtpmap:98 VP9/90000
+
+
+
+Uberti, et al.          Expires January 12, 2019               [Page 20]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    a=fmtp:98 max-fr=30; max-fs=3600; profile-id=0;
 
 6.2.2.  Offer/Answer Considerations
@@ -1114,14 +1140,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    o  To simplify the handling and matching of these configurations, the
       same RTP payload type number used in the offer SHOULD also be used
       in the answer, as specified in [RFC3264].  An answer MUST NOT
-
-
-
-Uberti, et al.          Expires January 12, 2019               [Page 20]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
-
       contain the payload type number used in the offer unless the
       configuration is exactly the same as in the offer.
 
@@ -1150,6 +1168,16 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    denial-of-service threat due to the receipt of pathological data.
    Nor does the RTP payload format contain any active content.
 
+
+
+
+
+
+Uberti, et al.          Expires January 12, 2019               [Page 21]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
 8.  Congestion Control
 
    Congestion control for RTP SHALL be used in accordance with RFC 3550
@@ -1167,16 +1195,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
    The IANA is requested to register the following values:
    - Media type registration as described in Section 6.1.
-
-
-
-
-
-
-Uberti, et al.          Expires January 12, 2019               [Page 21]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
 
 10.  References
 
@@ -1208,6 +1226,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               Applications", STD 64, RFC 3550, DOI 10.17487/RFC3550,
               July 2003, <https://www.rfc-editor.org/info/rfc3550>.
 
+
+
+
+Uberti, et al.          Expires January 12, 2019               [Page 22]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    [RFC4566]  Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
               Description Protocol", RFC 4566, DOI 10.17487/RFC4566,
               July 2006, <https://www.rfc-editor.org/info/rfc4566>.
@@ -1226,13 +1252,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               "Codec Control Messages in the RTP Audio-Visual Profile
               with Feedback (AVPF)", RFC 5104, DOI 10.17487/RFC5104,
               February 2008, <https://www.rfc-editor.org/info/rfc5104>.
-
-
-
-Uberti, et al.          Expires January 12, 2019               [Page 22]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
 
    [RFC6838]  Freed, N., Klensin, J., and T. Hansen, "Media Type
               Specifications and Registration Procedures", BCP 13,
@@ -1263,6 +1282,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               (RTP/SAVPF)", RFC 5124, DOI 10.17487/RFC5124, February
               2008, <https://www.rfc-editor.org/info/rfc5124>.
 
+
+
+
+Uberti, et al.          Expires January 12, 2019               [Page 23]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    [RFC7201]  Westerlund, M. and C. Perkins, "Options for Securing RTP
               Sessions", RFC 7201, DOI 10.17487/RFC7201, April 2014,
               <https://www.rfc-editor.org/info/rfc7201>.
@@ -1281,13 +1308,6 @@ Authors' Addresses
    USA
 
    Email: justin@uberti.name
-
-
-
-
-Uberti, et al.          Expires January 12, 2019               [Page 23]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
    Stefan Holmer
@@ -1318,6 +1338,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    Email: jonathan@vidyo.com
 
 
+
+
+
+Uberti, et al.          Expires January 12, 2019               [Page 24]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    Danny Hong
    Vidyo, Inc.
    433 Hackensack Avenue
@@ -1341,4 +1369,32 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.          Expires January 12, 2019               [Page 24]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Uberti, et al.          Expires January 12, 2019               [Page 25]

--- a/vp9/draft-ietf-payload-vp9-06.txt
+++ b/vp9/draft-ietf-payload-vp9-06.txt
@@ -89,12 +89,12 @@ Table of Contents
        6.2.1.  Mapping of Media Subtype Parameters to SDP  . . . . .  19
        6.2.2.  Offer/Answer Considerations . . . . . . . . . . . . .  20
    7.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
-   8.  Congestion Control  . . . . . . . . . . . . . . . . . . . . .  20
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
+   8.  Congestion Control  . . . . . . . . . . . . . . . . . . . . .  21
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  21
    10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  21
      10.1.  Normative References . . . . . . . . . . . . . . . . . .  21
      10.2.  Informative References . . . . . . . . . . . . . . . . .  22
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  22
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
 
@@ -1050,13 +1050,13 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
       string, in the form of a semicolon separated list of
       parameter=value pairs.
 
-6.2.1.1.  Example
+   o  The OPTIONAL parameter profile-id, when present, MUST be included
+      in the "a=fmtp" line of SDP.  This parameter is expressed as a
+      media subtype string, in the form of a parameter=value pair.
 
-   An example of media representation in SDP is as follows:
 
-   m=video 49170 RTP/AVPF 98
-   a=rtpmap:98 VP9/90000
-   a=fmtp:98 max-fr=30; max-fs=3600;
+
+
 
 
 
@@ -1066,9 +1066,32 @@ Uberti, et al.           Expires January 4, 2019               [Page 19]
 Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
+6.2.1.1.  Example
+
+   An example of media representation in SDP is as follows:
+
+   m=video 49170 RTP/AVPF 98
+   a=rtpmap:98 VP9/90000
+   a=fmtp:98 max-fr=30; max-fs=3600; profile-id=0;
+
 6.2.2.  Offer/Answer Considerations
 
-   TODO: Update this for VP9
+   When VP9 is offered over RTP using SDP in an Offer/Answer model
+   [RFC3264] for negotiation for unicast usage, the following
+   limitations and rules apply:
+
+   o  The parameter identifying a media format configuration for VP9 is
+      profile-id.  This media format configuration parameter MUST be
+      used symmetrically; that is, the answerer MUST either maintain all
+      configuration parameters or remove the media format (payload type)
+      completely if one or more of the parameter values are not
+      supported.
+
+   o  To simplify the handling and matching of these configurations, the
+      same RTP payload type number used in the offer SHOULD also be used
+      in the answer, as specified in [RFC3264].  An answer MUST NOT
+      contain the payload type number used in the offer unless the
+      configuration is exactly the same as in the offer.
 
 7.  Security Considerations
 
@@ -1091,6 +1114,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
    This RTP payload format and its media decoder do not exhibit any
    significant non-uniformity in the receiver-side computational
+
+
+
+Uberti, et al.           Expires January 4, 2019               [Page 20]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
+
    complexity for packet processing, and thus are unlikely to pose a
    denial-of-service threat due to the receipt of pathological data.
    Nor does the RTP payload format contain any active content.
@@ -1113,15 +1144,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    The IANA is requested to register the following values:
    - Media type registration as described in Section 6.1.
 
-
-
-
-
-Uberti, et al.           Expires January 4, 2019               [Page 20]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
-
 10.  References
 
 10.1.  Normative References
@@ -1141,6 +1163,20 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3264]  Rosenberg, J. and H. Schulzrinne, "An Offer/Answer Model
+              with Session Description Protocol (SDP)", RFC 3264,
+              DOI 10.17487/RFC3264, June 2002,
+              <https://www.rfc-editor.org/info/rfc3264>.
+
+
+
+
+
+Uberti, et al.           Expires January 4, 2019               [Page 21]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
 
    [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
               Jacobson, "RTP: A Transport Protocol for Real-Time
@@ -1171,13 +1207,6 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               RFC 6838, DOI 10.17487/RFC6838, January 2013,
               <https://www.rfc-editor.org/info/rfc6838>.
 
-
-
-Uberti, et al.           Expires January 4, 2019               [Page 21]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
-
    [VP9-BITSTREAM]
               Grange, A., de Rivaz, P., and J. Hunt, "VP9 Bitstream &
               Decoding Process Specification", Version 0.6, March 2016,
@@ -1196,6 +1225,14 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
               Norrman, "The Secure Real-time Transport Protocol (SRTP)",
               RFC 3711, DOI 10.17487/RFC3711, March 2004,
               <https://www.rfc-editor.org/info/rfc3711>.
+
+
+
+
+Uberti, et al.           Expires January 4, 2019               [Page 22]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
+
 
    [RFC5124]  Ott, J. and E. Carrara, "Extended Secure RTP Profile for
               Real-time Transport Control Protocol (RTCP)-Based Feedback
@@ -1222,18 +1259,6 @@ Authors' Addresses
    Email: justin@uberti.name
 
 
-
-
-
-
-
-
-
-Uberti, et al.           Expires January 4, 2019               [Page 22]
-
-Internet-Draft         RTP Payload Format for VP9              July 2018
-
-
    Stefan Holmer
    Google, Inc.
    Kungsbron 2
@@ -1250,6 +1275,19 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
    Sweden
 
    Email: mflodman@google.com
+
+
+
+
+
+
+
+
+
+
+Uberti, et al.           Expires January 4, 2019               [Page 23]
+
+Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
    Jonathan Lennox
@@ -1285,4 +1323,22 @@ Internet-Draft         RTP Payload Format for VP9              July 2018
 
 
 
-Uberti, et al.           Expires January 4, 2019               [Page 23]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Uberti, et al.           Expires January 4, 2019               [Page 24]

--- a/vp9/draft-ietf-payload-vp9-06.xml
+++ b/vp9/draft-ietf-payload-vp9-06.xml
@@ -901,11 +901,14 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
                 <t hangText="profile-id:">The value of profile-id is an integer
                 indicating the default coding profile, the subset of coding
 		tools that may have been used to generate the stream or that the
-		receiver supports). <xref target="TableOfProfiles"/> lists all
+		receiver supports). <xref target="TableOfProfileIds"/> lists all
 		of the profiles defined in section 7.2 of <xref target="VP9-BITSTREAM"/>
 		and the corresponding integer values to be used.</t>
 
 		<t>If no profile-id is present, Profile 0 MUST be inferred.</t>
+
+		<t>Informative note: See <xref target="TableOfProfiles"/> for capabilities
+		of coding profiles defined in section 7.2 of <xref target="VP9-BITSTREAM"/>.</t>
               </list></t>
 
             <t hangText="Encoding considerations:"><vspace blankLines="0"/>
@@ -950,15 +953,27 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
             Payload Working Group delegated from the IESG.</t>
           </list></t>
 
-	  <texttable anchor="TableOfProfiles" title="Table 1. Table of profile-id
+	  <texttable anchor="TableOfProfileIds" title="Table 1. Table of profile-id
 	  integer values representing the VP9 profile corresponding to the set of
-	  coding tools supported">
+	  coding tools supported.">
 		<ttcol align="center">Profile</ttcol>
 		<ttcol align="center">profile-id</ttcol>
 		<c>0</c><c>0</c>
 		<c>1</c><c>1</c>
 		<c>2</c><c>2</c>
 		<c>3</c><c>3</c>
+	  </texttable>
+
+	  <texttable anchor="TableOfProfiles" title="Table 2. Table of profile
+	  capabilities.">
+		<ttcol align="center">Profile</ttcol>
+		<ttcol align="center">Bit Depth</ttcol>
+		<ttcol align="center">SRGB Colorspace</ttcol>
+		<ttcol align="center">Chroma Subsampling</ttcol>
+		<c>0</c><c>8</c><c>No</c><c>YUV 4:2:0</c>
+		<c>1</c><c>8</c><c>Yes</c><c>YUV 4:2:0,4:4:0 or 4:4:4</c>
+		<c>2</c><c>10 or 12</c><c>No</c><c>YUV 4:2:0</c>
+		<c>3</c><c>10 or 12</c><c>Yes</c><c>YUV 4:2:0,4:4:0 or 4:4:4</c>
 	  </texttable>
       </section>
 

--- a/vp9/draft-ietf-payload-vp9-06.xml
+++ b/vp9/draft-ietf-payload-vp9-06.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
 <!ENTITY rfc2119 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
+<!ENTITY rfc3264 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3264.xml">
 <!ENTITY rfc3550 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3550.xml">
 <!ENTITY rfc3551 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3551.xml">
 <!ENTITY rfc3711 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3711.xml">
@@ -957,10 +958,15 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
               <t>The clock rate in the "a=rtpmap" line MUST be 90000.</t>
 
               <t>The parameters "max-fs", and "max-fr", MUST be included in
-              the "a=fmtp" line of SDP if SDP is used to declare receiver capabilities.
-				These parameters are expressed as a
-              media subtype string, in the form of a semicolon separated list
-              of parameter=value pairs.</t>
+              the "a=fmtp" line of SDP if SDP is used to declare receiver
+              capabilities. These parameters are expressed as a media subtype
+	      string, in the form of a semicolon separated list of
+	      parameter=value pairs.</t>
+
+              <t>The OPTIONAL parameter profile-id, when present, MUST be
+	      included in the "a=fmtp" line of SDP. This parameter is expressed
+	      as a media subtype string, in the form of a parameter=value
+	      pair.</t>
             </list></t>
 
           <section title="Example">
@@ -968,12 +974,11 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 
             <t>m=video 49170 RTP/AVPF 98<vspace blankLines="0"/> a=rtpmap:98
             VP9/90000<vspace blankLines="0"/> a=fmtp:98 max-fr=30;
-            max-fs=3600;<vspace blankLines="0"/></t>
+            max-fs=3600; profile-id=0;<vspace blankLines="0"/></t>
           </section>
         </section>
 
         <section title="Offer/Answer Considerations">
-		  <t>TODO: Update this for VP9</t>
 		  <!--
           <t>The VP9 codec offers a decode complexity that is roughly linear
           with the number of pixels encoded. The parameters "max-fr" and
@@ -983,6 +988,21 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
           establish these limits.</t>
 
            -->
+	  <t>When VP9 is offered over RTP using SDP in an Offer/Answer model
+          <xref target="RFC3264"/> for negotiation for unicast usage, the following
+          limitations and rules apply: <list style="symbols">
+	      <t>The parameter identifying a media format configuration for VP9 is
+	      profile-id. This media format configuration parameter MUST be used
+	      symmetrically; that is, the answerer MUST either maintain all
+	      configuration parameters or remove the media format (payload type)
+	      completely if one or more of the parameter values are not supported.</t>
+
+              <t>To simplify the handling and matching of these configurations, the
+              same RTP payload type number used in the offer SHOULD also be used
+              in the answer, as specified in <xref target="RFC3264"/>.  An answer
+	      MUST NOT contain the payload type number used in the offer unless the
+	      configuration is exactly the same as in the offer.</t>
+	  </list></t>
         </section>
       </section>
     </section>
@@ -1076,11 +1096,13 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 
       &rfc4855;
 
-	  &rfc5104;
+      &rfc5104;
 
-	  &lrr;
+      &lrr;
 
-	  &framemarking;
+      &framemarking;
+
+      &rfc3264;
 
     </references>
 

--- a/vp9/draft-ietf-payload-vp9-06.xml
+++ b/vp9/draft-ietf-payload-vp9-06.xml
@@ -897,6 +897,15 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
                 than int(sqrt(max-fs * 8)) - for instance, a max-fs of 1200
                 (capable of supporting 640x480 resolution) will support widths
                 and heights up to 1552 pixels (97 macroblocks).</t>
+
+                <t hangText="profile-id:">The value of profile-id is an integer
+                indicating the default coding profile, the subset of coding
+		tools that may have been used to generate the stream or that the
+		receiver supports). <xref target="TableOfProfiles"/> lists all
+		of the profiles defined in section 7.2 of <xref target="VP9-BITSTREAM"/>
+		and the corresponding integer values to be used.</t>
+
+		<t>If no profile-id is present, Profile 0 MUST be inferred.</t>
               </list></t>
 
             <t hangText="Encoding considerations:"><vspace blankLines="0"/>
@@ -940,6 +949,17 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
             <t hangText="Change controller:"><vspace blankLines="0"/> IETF
             Payload Working Group delegated from the IESG.</t>
           </list></t>
+
+	  <texttable anchor="TableOfProfiles" title="Table 1. Table of profile-id
+	  integer values representing the VP9 profile corresponding to the set of
+	  coding tools supported">
+		<ttcol align="center">Profile</ttcol>
+		<ttcol align="center">profile-id</ttcol>
+		<c>0</c><c>0</c>
+		<c>1</c><c>1</c>
+		<c>2</c><c>2</c>
+		<c>3</c><c>3</c>
+	  </texttable>
       </section>
 
       <section anchor="SDPParameters" title="SDP Parameters">
@@ -963,10 +983,11 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 	      string, in the form of a semicolon separated list of
 	      parameter=value pairs.</t>
 
-              <t>The OPTIONAL parameter profile-id, when present, MUST be
+              <t>The OPTIONAL parameter profile-id, when present, SHOULD be
 	      included in the "a=fmtp" line of SDP. This parameter is expressed
 	      as a media subtype string, in the form of a parameter=value
-	      pair.</t>
+	      pair. When the parameter is not present, a value of 0 MUST be
+	      used for profile-id.</t>
             </list></t>
 
           <section title="Example">
@@ -999,7 +1020,7 @@ N_G: | TID |U| R |-|-| (OPTIONAL)                 .
 
               <t>To simplify the handling and matching of these configurations, the
               same RTP payload type number used in the offer SHOULD also be used
-              in the answer, as specified in <xref target="RFC3264"/>.  An answer
+              in the answer, as specified in <xref target="RFC3264"/>. An answer
 	      MUST NOT contain the payload type number used in the offer unless the
 	      configuration is exactly the same as in the offer.</t>
 	  </list></t>


### PR DESCRIPTION
As a part of the plan to enable VP9 Profile 2(10-bit codec) in WebRTC, I edited the draft to explain profile negotiation. I mostly followed how H.264 is explained in RTC6184. 
The main reason why we need to distinguish VP9 profiles in advance for encoding and decoding is because we need to configure encoder/decoder implementations in advance, allocate buffers for input/output and make the decision to use HW/SW encoder knowing what we are receiving. In that way profiles should be similar to how H.264 works, minus the levels.